### PR TITLE
Fix bug - create entry with multiple locales, skip attributes for not localized fields in content type.

### DIFF
--- a/lib/contentful/management/dynamic_entry.rb
+++ b/lib/contentful/management/dynamic_entry.rb
@@ -39,12 +39,16 @@ module Contentful
               fields_for_query[field.id.to_sym]
             end
             define_method "#{ accessor_name }=" do |value|
-              fields[field.id.to_sym] = value
+              if field.localized || default_locale == locale
+                fields[field.id.to_sym] = value
+              end
             end
             define_method "#{ accessor_name }_with_locales=" do |values|
               values.each do |locale, value|
-                @fields[locale] = {} if @fields[locale].nil?
-                @fields[locale][field.id.to_sym] = value
+                if field.localized || default_locale == locale
+                  @fields[locale] = {} if @fields[locale].nil?
+                  @fields[locale][field.id.to_sym] = value
+                end
               end
             end
           end

--- a/lib/contentful/management/entry.rb
+++ b/lib/contentful/management/entry.rb
@@ -156,7 +156,7 @@ module Contentful
         fields_names.each_with_object({}) do |field_name, results|
           results[field_name] = raw_fields.each_with_object({}) do |(locale, fields), field_results|
             # field_results[locale] = fields[field_name]
-            field_results[locale] = parse_update_attribute(fields[field_name])
+            field_results[locale] = parse_update_attribute(fields[field_name]) unless fields[field_name].nil?
           end
         end
       end

--- a/spec/fixtures/vcr_cassettes/content_type/entry/create_only_with_localized_fields.yml
+++ b/spec/fixtures/vcr_cassettes/content_type/entry/create_only_with_localized_fields.yml
@@ -1,0 +1,217 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/content_types/category_content_type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:15:34 GMT
+      Etag:
+      - '"391c3aafd988f750695ae5676d7130d6"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1254'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "displayField": "name",
+          "name": "Category",
+          "description": "",
+          "fields": [
+            {
+              "id": "name",
+              "name": "Name",
+              "type": "Text",
+              "localized": true,
+              "uiid": "3ic0t3qi51c"
+            },
+            {
+              "id": "description",
+              "name": "Description",
+              "type": "Text",
+              "localized": false,
+              "uiid": "38xiq8fobnk"
+            }
+          ],
+          "sys": {
+            "id": "category_content_type",
+            "type": "ContentType",
+            "createdAt": "2014-08-21T13:32:20.955Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "v2umtz8ths9v"
+              }
+            },
+            "firstPublishedAt": "2014-08-21T13:32:27.109Z",
+            "publishedCounter": 6,
+            "publishedAt": "2014-09-02T07:13:04.738Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "publishedVersion": 17,
+            "version": 18,
+            "updatedAt": "2014-09-02T07:13:04.749Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:16:05 GMT
+- request:
+    method: post
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/entries/
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Contentful EN","de-DE":"Contentful DE","pl-PL":"Contentful
+        PL"},"description":{"en-US":"Description EN"}}}'
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Content-Type:
+      - category_content_type
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:15:35 GMT
+      Etag:
+      - '"31fdedb609685a76a992f08ab55226a6"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '932'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Contentful EN",
+              "de-DE": "Contentful DE",
+              "pl-PL": "Contentful PL"
+            },
+            "description": {
+              "en-US": "Description EN"
+            }
+          },
+          "sys": {
+            "id": "3SxjTVeUF2AEKg6kQQS4MG",
+            "type": "Entry",
+            "version": 1,
+            "createdAt": "2014-09-02T08:15:35.205Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "v2umtz8ths9v"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category_content_type"
+              }
+            },
+            "updatedAt": "2014-09-02T08:15:35.205Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:16:06 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr_cassettes/content_type/entry/create_to_single_locale_only_with_localized_fields.yml
+++ b/spec/fixtures/vcr_cassettes/content_type/entry/create_to_single_locale_only_with_localized_fields.yml
@@ -1,0 +1,216 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/content_types/category_content_type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:30:29 GMT
+      Etag:
+      - '"391c3aafd988f750695ae5676d7130d6"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1254'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "displayField": "name",
+          "name": "Category",
+          "description": "",
+          "fields": [
+            {
+              "id": "name",
+              "name": "Name",
+              "type": "Text",
+              "localized": true,
+              "uiid": "3ic0t3qi51c"
+            },
+            {
+              "id": "description",
+              "name": "Description",
+              "type": "Text",
+              "localized": false,
+              "uiid": "38xiq8fobnk"
+            }
+          ],
+          "sys": {
+            "id": "category_content_type",
+            "type": "ContentType",
+            "createdAt": "2014-08-21T13:32:20.955Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "v2umtz8ths9v"
+              }
+            },
+            "firstPublishedAt": "2014-08-21T13:32:27.109Z",
+            "publishedCounter": 6,
+            "publishedAt": "2014-09-02T07:13:04.738Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "publishedVersion": 17,
+            "version": 18,
+            "updatedAt": "2014-09-02T07:13:04.749Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:31:00 GMT
+- request:
+    method: post
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/entries/
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Some testing EN name","de-DE":"Some testing
+        DE name"},"description":{"en-US":" some testing EN description "}}}'
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Content-Type:
+      - category_content_type
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:31:37 GMT
+      Etag:
+      - '"abd826904285bae23b9376889f05addc"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '929'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Some testing EN name",
+              "de-DE": "Some testing DE name"
+            },
+            "description": {
+              "en-US": " some testing EN description "
+            }
+          },
+          "sys": {
+            "id": "6qBPO7KqXYq6e48ywam88a",
+            "type": "Entry",
+            "version": 1,
+            "createdAt": "2014-09-02T08:31:37.485Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "v2umtz8ths9v"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category_content_type"
+              }
+            },
+            "updatedAt": "2014-09-02T08:31:37.485Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:32:08 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr_cassettes/content_type/entry/update_only_with_localized_fields.yml
+++ b/spec/fixtures/vcr_cassettes/content_type/entry/update_only_with_localized_fields.yml
@@ -1,0 +1,574 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:17:17 GMT
+      Etag:
+      - '"35407b8a88882fe5717a4701910f6ce7"'
+      Server:
+      - nginx
+      Status:
+      - 200 OK
+      X-Contentful-Request-Id:
+      - f1c-1375556194
+      Content-Length:
+      - '459'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys":{
+            "type":"Space",
+            "id":"v2umtz8ths9v",
+            "version":1,
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "createdAt":"2014-08-21T13:32:11Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "updatedAt":"2014-08-21T13:32:12Z"
+          },
+          "name":"CMA Demo Rails App"}
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:17:48 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/content_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:17:18 GMT
+      Etag:
+      - '"da68e0b0911d1f09a5959ee568e6af90"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '5193'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys": {
+            "type": "Array"
+          },
+          "total": 3,
+          "skip": 0,
+          "limit": 100,
+          "items": [
+            {
+              "fields": [
+                {
+                  "name": "testowe",
+                  "id": "testowe",
+                  "type": "Link",
+                  "uiid": "3q907mcb4lc",
+                  "linkType": "Asset",
+                  "required": true,
+                  "localized": true
+                }
+              ],
+              "name": "test",
+              "sys": {
+                "id": "26eLfV14SIOeQkse44q4sw",
+                "type": "ContentType",
+                "createdAt": "2014-08-22T12:57:43.618Z",
+                "createdBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "space": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "v2umtz8ths9v"
+                  }
+                },
+                "firstPublishedAt": "2014-08-22T12:57:53.093Z",
+                "publishedCounter": 2,
+                "publishedAt": "2014-08-22T12:57:58.628Z",
+                "publishedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "publishedVersion": 13,
+                "version": 14,
+                "updatedAt": "2014-08-22T12:57:58.633Z",
+                "updatedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                }
+              }
+            },
+            {
+              "displayField": "title",
+              "name": "Post",
+              "description": "",
+              "fields": [
+                {
+                  "id": "title",
+                  "name": "Title",
+                  "type": "Text",
+                  "localized": true,
+                  "uiid": "2sdir2f8kcg"
+                },
+                {
+                  "id": "author",
+                  "name": "Author",
+                  "type": "Text",
+                  "localized": true,
+                  "uiid": "4x1018907pc"
+                },
+                {
+                  "id": "body",
+                  "name": "Body",
+                  "type": "Text",
+                  "localized": true,
+                  "uiid": "4hj7cda89hc"
+                },
+                {
+                  "id": "title_image",
+                  "name": "Title Image",
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "required": true,
+                  "localized": true,
+                  "uiid": "4gcqrcma8lc"
+                },
+                {
+                  "id": "second_image",
+                  "name": "Second Image",
+                  "type": "Link",
+                  "linkType": "Asset",
+                  "localized": true,
+                  "uiid": "40440elrugw"
+                },
+                {
+                  "id": "category",
+                  "name": "Category",
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "uiid": "49vicjvqsxs",
+                  "localized": true
+                }
+              ],
+              "sys": {
+                "id": "post_content_type",
+                "type": "ContentType",
+                "createdAt": "2014-08-21T13:32:30.401Z",
+                "createdBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "space": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "v2umtz8ths9v"
+                  }
+                },
+                "firstPublishedAt": "2014-08-21T13:32:43.385Z",
+                "publishedCounter": 2,
+                "publishedAt": "2014-08-27T09:18:36.995Z",
+                "publishedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "publishedVersion": 11,
+                "version": 12,
+                "updatedAt": "2014-08-27T09:18:37.003Z",
+                "updatedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                }
+              }
+            },
+            {
+              "displayField": "name",
+              "name": "Category",
+              "description": "",
+              "fields": [
+                {
+                  "id": "name",
+                  "name": "Name",
+                  "type": "Text",
+                  "localized": true,
+                  "uiid": "3ic0t3qi51c"
+                },
+                {
+                  "id": "description",
+                  "name": "Description",
+                  "type": "Text",
+                  "localized": false,
+                  "uiid": "38xiq8fobnk"
+                }
+              ],
+              "sys": {
+                "id": "category_content_type",
+                "type": "ContentType",
+                "createdAt": "2014-08-21T13:32:20.955Z",
+                "createdBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "space": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "v2umtz8ths9v"
+                  }
+                },
+                "firstPublishedAt": "2014-08-21T13:32:27.109Z",
+                "publishedCounter": 6,
+                "publishedAt": "2014-09-02T07:13:04.738Z",
+                "publishedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "publishedVersion": 17,
+                "version": 18,
+                "updatedAt": "2014-09-02T07:13:04.749Z",
+                "updatedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                }
+              }
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:17:49 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/entries/2dEkgsQRnSW2QuW4AMaa86
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:17:19 GMT
+      Etag:
+      - '"a7b89987eefc47f65b3e43defb6c762f"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1229'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Contentful EN",
+              "de-DE": "Contentful DE",
+              "pl-PL": "Contentful PL"
+            },
+            "description": {
+              "en-US": "Description EN"
+            }
+          },
+          "sys": {
+            "id": "2dEkgsQRnSW2QuW4AMaa86",
+            "type": "Entry",
+            "createdAt": "2014-09-02T07:35:22.045Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "v2umtz8ths9v"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category_content_type"
+              }
+            },
+            "firstPublishedAt": "2014-09-02T07:35:30.549Z",
+            "publishedCounter": 1,
+            "publishedAt": "2014-09-02T07:35:30.549Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "publishedVersion": 14,
+            "version": 17,
+            "updatedAt": "2014-09-02T08:15:33.662Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:17:50 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/v2umtz8ths9v/entries/2dEkgsQRnSW2QuW4AMaa86
+    body:
+      encoding: UTF-8
+      string: '{"fields":{"name":{"en-US":"Contentful EN up","de-DE":"Contentful DE
+        up","pl-PL":"Contentful PL up"},"description":{"en-US":"Description EN up"}}}'
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.1.0
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '17'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Cf-Space-Id:
+      - v2umtz8ths9v
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Date:
+      - Tue, 02 Sep 2014 08:17:19 GMT
+      Etag:
+      - '"a12c023d89243e0b17cc9ce12eab9344"'
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Content-Length:
+      - '1241'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "fields": {
+            "name": {
+              "en-US": "Contentful EN up",
+              "de-DE": "Contentful DE up",
+              "pl-PL": "Contentful PL up"
+            },
+            "description": {
+              "en-US": "Description EN up"
+            }
+          },
+          "sys": {
+            "id": "2dEkgsQRnSW2QuW4AMaa86",
+            "type": "Entry",
+            "createdAt": "2014-09-02T07:35:22.045Z",
+            "createdBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "space": {
+              "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "v2umtz8ths9v"
+              }
+            },
+            "contentType": {
+              "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category_content_type"
+              }
+            },
+            "firstPublishedAt": "2014-09-02T07:35:30.549Z",
+            "publishedCounter": 1,
+            "publishedAt": "2014-09-02T07:35:30.549Z",
+            "publishedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "publishedVersion": 14,
+            "version": 18,
+            "updatedAt": "2014-09-02T08:17:19.788Z",
+            "updatedBy": {
+              "sys": {
+                "type": "Link",
+                "linkType": "User",
+                "id": "1E7acJL8I5XUXAMHQt9Grs"
+              }
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 02 Sep 2014 08:17:51 GMT
+recorded_with: VCR 2.9.2

--- a/spec/lib/contentful/management/content_type_spec.rb
+++ b/spec/lib/contentful/management/content_type_spec.rb
@@ -239,6 +239,18 @@ module Contentful
             expect(content_type.fields.size).to eq 1
           end
         end
+
+        it 'update with multiple locales' do
+          vcr('content_type/entry/update_only_with_localized_fields') do
+            space = Contentful::Management::Space.find('v2umtz8ths9v')
+            entry = space.entries.find('2dEkgsQRnSW2QuW4AMaa86')
+            entry.name_with_locales = {'en-US' => 'Contentful EN up', 'de-DE' => 'Contentful DE up', 'pl-PL' => 'Contentful PL up'}
+            entry.description_with_locales = {'en-US' => 'Description EN up', 'de-DE' => 'Description DE up', 'pl-PL' => 'Description PL up'}
+            entry.save
+            expect(entry).to be_kind_of Contentful::Management::Entry
+          end
+        end
+
       end
 
       describe '#save' do
@@ -459,6 +471,36 @@ module Contentful
               entry.blog_entry_with_locales = {'en-US' => entry_en, 'pl' => entry_pl}
               entry.save
               expect(entry.blog_name).to eq 'Contentful en'
+            end
+          end
+
+          context 'only to unlocalized fields' do
+            it 'return entry with valid parameters' do
+              vcr('content_type/entry/create_only_with_localized_fields') do
+                content_type = subject.find('v2umtz8ths9v', 'category_content_type')
+                entry = content_type.entries.new
+                entry.name_with_locales = {'en-US' => 'Contentful EN', 'de-DE' => 'Contentful DE', 'pl-PL' => 'Contentful PL'}
+                entry.description_with_locales = {'en-US' => 'Description EN', 'de-DE' => 'Description DE', 'pl-PL' => 'Description PL'}
+                entry.save
+                expect(entry).to be_kind_of Contentful::Management::Entry
+              end
+            end
+          end
+        end
+        context 'to single locale' do
+          context 'only to unlocalized fields' do
+            it 'return entry with valid parameters' do
+              vcr('content_type/entry/create_to_single_locale_only_with_localized_fields') do
+                content_type = subject.find('v2umtz8ths9v', 'category_content_type')
+                entry = content_type.entries.new
+                entry.name = 'Some testing EN name'
+                entry.description= ' some testing EN description '
+                entry.locale = 'de-DE'
+                entry.name = 'Some testing DE name'
+                entry.description= ' some testing DE description'
+                entry.save
+                expect(entry).to be_kind_of Contentful::Management::Entry
+              end
             end
           end
         end


### PR DESCRIPTION
Create / update an entry for not localized fields, the object will be created correctly for localized fields, skip not localized one and avoid validation error.
