### PR TITLE
! Keep attribute if it's already a hash

### DIFF
--- a/lib/contentful/management/entry.rb
+++ b/lib/contentful/management/entry.rb
@@ -244,6 +244,8 @@ module Contentful
                      hash_with_link_object('Entry', attr)
                    when Asset then
                      hash_with_link_object('Asset', attr)
+                   when Hash then
+                     attr
                  end
         end
       end

--- a/spec/lib/contentful/management/entry_spec.rb
+++ b/spec/lib/contentful/management/entry_spec.rb
@@ -604,6 +604,15 @@ module Contentful
 
         end
 
+        it 'keepd hashes in attributes' do
+          attributes = {
+            entries: [{sys: {type: 'Link', linkType: 'Entry', id: nil}}, {sys: {type: 'Link', linkType: 'Entry', id: nil}}]
+          }
+
+          parsed_attributes = Entry.new.fields_from_attributes(attributes)
+
+          expect(parsed_attributes[:entries]).to match('en-US' => [{sys: {type: 'Link', linkType: 'Entry', id: nil}}, {sys: {type: 'Link', linkType: 'Entry', id: nil}}])
+        end
       end
 
     end


### PR DESCRIPTION
Fixes a bug with updating entries with one to many associations.
- Scenario:
  - Collection that has many Entries and description
  - I want to update the description via `entry.update`
- What happens:
  - `entry.fields[:entries]` array already includes the entries in the required hash format but is then parsed
  - the parser checks the type of the attribute
  - type is neither `Asset` nor `Entry`
  - `nil` replaces entry that does not require parsing
- Suggested solution:
  - keep the entry in the array if it's already a hash 
