### PR TITLE
Do not lose displayField on update when not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * Fix access to space default_locale instance variable [#47](https://github.com/contentful/contentful-management.rb/pull/47)
 * Better handling of 503 responses from the API [#48](https://github.com/contentful/contentful-management.rb/pull/48)
+* Do Not lose displayField on update when not set [#52](https://github.com/contentful/contentful-management.rb/pull/52)
 
 
 ## 0.6.0

--- a/lib/contentful/management/content_type.rb
+++ b/lib/contentful/management/content_type.rb
@@ -29,6 +29,7 @@ module Contentful
       property :name, :string
       property :description, :string
       property :fields, Field
+      property :displayField, :string
 
       # Gets a collection of content types.
       # Takes an id of space and an optional hash of query options
@@ -122,7 +123,7 @@ module Contentful
       # Returns a Contentful::Management::ContentType.
       def update(attributes)
         parameters = {}
-        parameters.merge!(displayField: attributes[:displayField]) if  attributes[:displayField]
+        parameters.merge!(displayField: attributes[:displayField] || display_field)
         parameters.merge!(name: (attributes[:name] || name))
         parameters.merge!(description: (attributes[:description] || description))
         parameters.merge!(fields: self.class.fields_to_nested_properties_hash(attributes[:fields] || fields))


### PR DESCRIPTION
The displayField attribute was reset on calling update without a set
displayField.

This fixes #51