### PR TITLE
Explicitly set displayField to nil when not existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 * Add disable property to fields [#50](https://github.com/contentful/contentful-management.rb/pull/50), [#55](https://github.com/contentful/contentful-management.rb/pull/55)
 
+### Fixed
+* Explicitly set displayField to nil when it is not existing [#53](https://github.com/contentful/contentful-management.rb/pull/53), [#54](https://github.com/contentful/contentful-management.rb/pull/54)
+
+
 
 ## 0.6.1
 ### Fixed
@@ -16,6 +20,7 @@
 ## 0.6.0
 ### Added
 * Access request and response from Contentful::Management:Error [#46](https://github.com/contentful/contentful-management.rb/pull/46)
+
 ### Fixed
 * Handle 429 responses as errors [#46](https://github.com/contentful/contentful-management.rb/pull/46)
 

--- a/lib/contentful/management/content_type.rb
+++ b/lib/contentful/management/content_type.rb
@@ -118,12 +118,20 @@ module Contentful
         result
       end
 
+      def display_field_value(attributes)
+        if attributes[:displayField].nil? && display_field.empty?
+          nil
+        else
+          attributes[:displayField] || display_field
+        end
+      end
+
       # Updates a content type.
       # Takes a hash with attributes.
       # Returns a Contentful::Management::ContentType.
       def update(attributes)
         parameters = {}
-        parameters.merge!(displayField: attributes[:displayField] || display_field)
+        parameters.merge!(displayField: display_field_value(attributes))
         parameters.merge!(name: (attributes[:name] || name))
         parameters.merge!(description: (attributes[:description] || description))
         parameters.merge!(fields: self.class.fields_to_nested_properties_hash(attributes[:fields] || fields))


### PR DESCRIPTION
This is a POC to fix #53. 
I am not happy with the code by far but it seems to work.

Creating a content type with one field that is not the title, then update the name 
and trying to activate it worked with this code.

We explicitly set the displayField property to nil when it was neither passed in
as an attribute or was already set.

This needs to be refactored to something nicer than this right now.