### PR TITLE
Adds handling for spaces with already existing default locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Master
 ### Fixed
 * Ensure that `Validation.type` returns correct value [#59](https://github.com/contentful/contentful-management.rb/issues/59), [#66](https://github.com/contentful/contentful-management.rb/issues/66)
+* Ensure that already existing `Space` returns correct `Locale` for `#default_locale` [#60](https://github.com/contentful/contentful-management.rb/issues/60)
 
 
 ## 0.7.1

--- a/lib/contentful/management/locale.rb
+++ b/lib/contentful/management/locale.rb
@@ -13,6 +13,7 @@ module Contentful
       property :contentManagementApi, :boolean
       property :contentDeliveryApi, :boolean
       property :publish, :boolean
+      property :default, :boolean
 
       # Gets a collection of locales.
       # Takes an id of a space.

--- a/lib/contentful/management/space.rb
+++ b/lib/contentful/management/space.rb
@@ -150,7 +150,9 @@ module Contentful
       # Finds Default Locale Code for current Space
       # This request makes an API call to the Locale endpoint
       def find_locale
-        ::Contentful::Management::Locale.all(self.id).first.code
+        locale = ::Contentful::Management::Locale.all(self.id).detect { |l| l.default }
+        return locale.code unless locale.nil?
+        @default_locale
       end
     end
   end

--- a/lib/contentful/management/space.rb
+++ b/lib/contentful/management/space.rb
@@ -23,7 +23,7 @@ module Contentful
       property :organization, :string
       property :locales, Locale
 
-      attr_accessor :found, :found_locale
+      attr_accessor :found_locale
 
       # Gets a collection of spaces.
       # Returns a Contentful::Management::Array of Contentful::Management::Space.
@@ -32,9 +32,6 @@ module Contentful
         response = request.get
         result = ResourceBuilder.new(response, {}, {})
         spaces = result.run
-        spaces.each do |space|
-          space.found = true
-        end
         client.update_dynamic_entry_cache_for_spaces!(spaces)
         spaces
       end
@@ -47,7 +44,6 @@ module Contentful
         response = request.get
         result = ResourceBuilder.new(response, {}, {})
         space = result.run
-        space.found = true if space.is_a? Space
         client.update_dynamic_entry_cache_for_space!(space) if space.is_a? Space
         space
       end
@@ -65,7 +61,9 @@ module Contentful
         )
         response = request.post
         result = ResourceBuilder.new(response, {}, {})
-        result.run
+        space = result.run
+        space.found_locale = default_locale if space.is_a? Space
+        space
       end
 
       # Updates a space.
@@ -144,7 +142,7 @@ module Contentful
 
       # Retrieves Default Locale for current Space and leaves it cached
       def default_locale
-        self.found_locale ||= self.found ? find_locale : @default_locale
+        self.found_locale ||= find_locale
       end
 
       # Finds Default Locale Code for current Space

--- a/lib/contentful/management/space.rb
+++ b/lib/contentful/management/space.rb
@@ -23,6 +23,8 @@ module Contentful
       property :organization, :string
       property :locales, Locale
 
+      attr_accessor :found, :found_locale
+
       # Gets a collection of spaces.
       # Returns a Contentful::Management::Array of Contentful::Management::Space.
       def self.all
@@ -30,6 +32,9 @@ module Contentful
         response = request.get
         result = ResourceBuilder.new(response, {}, {})
         spaces = result.run
+        spaces.each do |space|
+          space.found = true
+        end
         client.update_dynamic_entry_cache_for_spaces!(spaces)
         spaces
       end
@@ -42,6 +47,7 @@ module Contentful
         response = request.get
         result = ResourceBuilder.new(response, {}, {})
         space = result.run
+        space.found = true if space.is_a? Space
         client.update_dynamic_entry_cache_for_space!(space) if space.is_a? Space
         space
       end
@@ -134,6 +140,17 @@ module Contentful
       # See README for details.
       def webhooks
         SpaceWebhookMethodsFactory.new(self)
+      end
+
+      # Retrieves Default Locale for current Space and leaves it cached
+      def default_locale
+        self.found_locale ||= self.found ? find_locale : @default_locale
+      end
+
+      # Finds Default Locale Code for current Space
+      # This request makes an API call to the Locale endpoint
+      def find_locale
+        ::Contentful::Management::Locale.all(self.id).first.code
       end
     end
   end

--- a/spec/fixtures/vcr_cassettes/locale/find_default.yml
+++ b/spec/fixtures/vcr_cassettes/locale/find_default.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/n6spjc167pc2/locales/0X5xcjckv6RMrd9Trae81p
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.0.1
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 14 Jul 2014 07:44:57 GMT
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '703'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Contentful-Request-Id:
+      - 85f-1209864303
+      Etag:
+      - '"84473d86f0e8887dd6b44d2ffe155176"'
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys":{
+            "type":"Locale",
+            "id":"0X5xcjckv6RMrd9Trae81p",
+            "version":6,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"n6spjc167pc2"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "createdAt":"2014-07-11T10:43:30Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "updatedAt":"2014-07-11T13:29:23Z"
+          },
+          "name":"testNewLocaleName",
+          "code":"pl",
+          "default":true,
+          "contentManagementApi":true,
+          "publish":true,
+          "contentDeliveryApi":true}
+    http_version: 
+  recorded_at: Mon, 14 Jul 2014 07:44:57 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr_cassettes/locale/find_not_default.yml
+++ b/spec/fixtures/vcr_cassettes/locale/find_not_default.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/n6spjc167pc2/locales/0X5xcjckv6RMrd9Trae81p
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.0.1
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 14 Jul 2014 07:44:57 GMT
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '703'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Contentful-Request-Id:
+      - 85f-1209864303
+      Etag:
+      - '"84473d86f0e8887dd6b44d2ffe155176"'
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys":{
+            "type":"Locale",
+            "id":"0X5xcjckv6RMrd9Trae81p",
+            "version":6,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"n6spjc167pc2"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "createdAt":"2014-07-11T10:43:30Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "updatedAt":"2014-07-11T13:29:23Z"
+          },
+          "name":"testNewLocaleName",
+          "code":"pl",
+          "default":false,
+          "contentManagementApi":true,
+          "publish":true,
+          "contentDeliveryApi":true}
+    http_version: 
+  recorded_at: Mon, 14 Jul 2014 07:44:57 GMT
+recorded_with: VCR 2.9.2

--- a/spec/fixtures/vcr_cassettes/space/locale/find_other_locale.yml
+++ b/spec/fixtures/vcr_cassettes/space/locale/find_other_locale.yml
@@ -1,0 +1,572 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/yr5m0jky5hsh
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.0.1
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 31 Jul 2014 07:10:02 GMT
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '453'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Contentful-Request-Id:
+      - 85f-1334431491
+      Etag:
+      - '"cbeabcb3476920c3f3a426f8cf41795d"'
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys":{
+            "type":"Space",
+            "id":"yr5m0jky5hsh",
+            "version":8,
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"0fn5fOWn4WsKFyYla1gI5h"
+              }
+            },
+            "createdAt":"2014-07-30T07:46:19Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"1E7acJL8I5XUXAMHQt9Grs"
+              }
+            },
+            "updatedAt":"2014-07-31T07:04:29Z"
+          },
+          "name":"NewNameSpace"}
+    http_version: 
+  recorded_at: Thu, 31 Jul 2014 07:10:02 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/yr5m0jky5hsh/content_types
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.0.1
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 31 Jul 2014 07:10:02 GMT
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '3054'
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Express
+      Cf-Space-Id:
+      - yr5m0jky5hsh
+      Etag:
+      - '"4c43b6e34924f7e65971295370191384"'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys": {
+            "type": "Array"
+          },
+          "total": 1,
+          "skip": 0,
+          "limit": 100,
+          "items": [
+            {
+              "fields": [
+                {
+                  "name": "name",
+                  "id": "name",
+                  "type": "Text",
+                  "uiid": "3fflnrplhc0",
+                  "localized": true
+                },
+                {
+                  "name": "age",
+                  "id": "age",
+                  "uiid": "2t5blkc7u2o",
+                  "type": "Integer",
+                  "localized": true
+                },
+                {
+                  "name": "city",
+                  "id": "city",
+                  "type": "Location",
+                  "uiid": "4fzl5jkm1a8",
+                  "localized": false
+                },
+                {
+                  "name": "assets",
+                  "id": "assets",
+                  "uiid": "3aqrgdyesxs",
+                  "type": "Array",
+                  "items": {
+                    "type": "Link",
+                    "linkType": "Asset"
+                  },
+                  "localized": true
+                },
+                {
+                  "name": "entries",
+                  "id": "entries",
+                  "type": "Array",
+                  "uiid": "3xi486kbchs",
+                  "items": {
+                    "type": "Link",
+                    "linkType": "Entry"
+                  }
+                },
+                {
+                  "name": "entry",
+                  "id": "entry",
+                  "type": "Link",
+                  "uiid": "3uxjdd1n5ds",
+                  "linkType": "Entry"
+                },
+                {
+                  "name": "asset",
+                  "id": "asset",
+                  "type": "Link",
+                  "uiid": "40ilp8h1xc0",
+                  "linkType": "Asset"
+                },
+                {
+                  "name": "bool",
+                  "id": "bool",
+                  "type": "Boolean",
+                  "uiid": "2i1bgmn2dj4",
+                  "localized": true
+                },
+                {
+                  "name": "symbols",
+                  "id": "symbols",
+                  "type": "Array",
+                  "uiid": "38rbncxmzuo",
+                  "items": {
+                    "type": "Symbol"
+                  }
+                },
+                {
+                  "name": "birthday",
+                  "id": "birthday",
+                  "type": "Date",
+                  "uiid": "41bdwbk06bk"
+                }
+              ],
+              "name": "Author",
+              "sys": {
+                "id": "5DSpuKrl04eMAGQoQckeIq",
+                "type": "ContentType",
+                "createdAt": "2014-07-30T12:35:01.110Z",
+                "createdBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "space": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "Space",
+                    "id": "yr5m0jky5hsh"
+                  }
+                },
+                "firstPublishedAt": "2014-07-30T12:37:42.035Z",
+                "publishedCounter": 6,
+                "publishedAt": "2014-07-30T14:58:40.786Z",
+                "publishedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "publishedVersion": 177,
+                "version": 178,
+                "updatedAt": "2014-07-30T14:58:40.796Z",
+                "updatedBy": {
+                  "sys": {
+                    "type": "Link",
+                    "linkType": "User",
+                    "id": "1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                }
+              },
+              "description": null,
+              "displayField": "name"
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Thu, 31 Jul 2014 07:10:02 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/yr5m0jky5hsh/locales
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.0.1
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 31 Jul 2014 07:10:03 GMT
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '3463'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Contentful-Request-Id:
+      - 85f-1334431493
+      Etag:
+      - '"39640635b4519a9604d27cb6b3a979b3"'
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys":{
+            "type":"Array"
+          },
+          "items":[
+            {
+              "sys":{
+                "type":"Locale",
+                "id":"42irhRZ5uMrRc9SZ1PyDRk",
+                "version":0,
+                "space":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"Space",
+                    "id":"yr5m0jky5hsh"
+                  }
+                },
+                "createdBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"0fn5fOWn4WsKFyYla1gI5h"
+                  }
+                },
+                "createdAt":"2014-07-30T07:46:19Z",
+                "updatedBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"0fn5fOWn4WsKFyYla1gI5h"
+                  }
+                },
+                "updatedAt":"2014-07-30T07:46:19Z"
+              },
+              "name":"German",
+              "code":"de-DE",
+              "default":true,
+              "contentManagementApi":true,
+              "publish":true,
+              "contentDeliveryApi":true
+            },
+            {
+              "sys":{
+                "type":"Locale",
+                "id":"3QwNQbA5IApftHq2TqWzbw",
+                "version":1,
+                "space":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"Space",
+                    "id":"yr5m0jky5hsh"
+                  }
+                },
+                "createdBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "createdAt":"2014-07-30T11:56:41Z",
+                "updatedBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "updatedAt":"2014-07-30T12:05:44Z"
+              },
+              "name":"Polish - PL",
+              "code":"pl-PL",
+              "default":false,
+              "contentManagementApi":true,
+              "publish":true,
+              "contentDeliveryApi":true
+            },
+            {
+              "sys":{
+                "type":"Locale",
+                "id":"3V5DI3HspzHXRhUuNNW8x8",
+                "version":0,
+                "space":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"Space",
+                    "id":"yr5m0jky5hsh"
+                  }
+                },
+                "createdBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "createdAt":"2014-07-30T11:56:45Z",
+                "updatedBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "updatedAt":"2014-07-30T11:56:45Z"
+              },
+              "name":"Polish",
+              "code":"pl",
+              "default":false,
+              "contentManagementApi":true,
+              "publish":true,
+              "contentDeliveryApi":true
+            },
+            {
+              "sys":{
+                "type":"Locale",
+                "id":"7E40Gt0Du4KBPwfw7pPw2O",
+                "version":0,
+                "space":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"Space",
+                    "id":"yr5m0jky5hsh"
+                  }
+                },
+                "createdBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "createdAt":"2014-07-30T12:07:20Z",
+                "updatedBy":{
+                  "sys":{
+                    "type":"Link",
+                    "linkType":"User",
+                    "id":"1E7acJL8I5XUXAMHQt9Grs"
+                  }
+                },
+                "updatedAt":"2014-07-30T12:07:20Z"
+              },
+              "name":"Belgium",
+              "code":"bl-BL",
+              "default":false,
+              "contentManagementApi":true,
+              "publish":true,
+              "contentDeliveryApi":true
+            }
+          ],
+          "total":4,
+          "limit":25,
+          "skip":0}
+    http_version: 
+  recorded_at: Thu, 31 Jul 2014 07:10:03 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/yr5m0jky5hsh/locales/42irhRZ5uMrRc9SZ1PyDRk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - RubyContenfulManagementGem/0.0.1
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '0'
+      Host:
+      - api.contentful.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 31 Jul 2014 07:10:04 GMT
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Content-Length:
+      - '700'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Contentful-Request-Id:
+      - 85f-1334431494
+      Etag:
+      - '"223ca1fe077cffa1fe228a6303f2b0c8"'
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      "^access-Control-Expose-Headers":
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "sys":{
+            "type":"Locale",
+            "id":"42irhRZ5uMrRc9SZ1PyDRk",
+            "version":0,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"yr5m0jky5hsh"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"0fn5fOWn4WsKFyYla1gI5h"
+              }
+            },
+            "createdAt":"2014-07-30T07:46:19Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"0fn5fOWn4WsKFyYla1gI5h"
+              }
+            },
+            "updatedAt":"2014-07-30T07:46:19Z"
+          },
+          "name":"German",
+          "code":"de-DE",
+          "default":true,
+          "contentManagementApi":true,
+          "publish":true,
+          "contentDeliveryApi":true}
+    http_version: 
+  recorded_at: Thu, 31 Jul 2014 07:10:04 GMT
+recorded_with: VCR 2.9.2

--- a/spec/lib/contentful/management/locale_spec.rb
+++ b/spec/lib/contentful/management/locale_spec.rb
@@ -61,6 +61,21 @@ module Contentful
           end
         end
       end
+
+      describe '#default' do
+        it 'is false for non default' do
+          vcr('locale/find_not_default') do
+            locale = subject.find(space_id, locale_id)
+            expect(locale.default).to be_falsey
+          end
+        end
+        it 'is true for default' do
+          vcr('locale/find_default') do
+            locale = subject.find(space_id, locale_id)
+            expect(locale.default).to be_truthy
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/contentful/management/space_spec.rb
+++ b/spec/lib/contentful/management/space_spec.rb
@@ -38,7 +38,7 @@ module Contentful
           end
         end
         it 'returns space for a given key' do
-          vcr('space/find') do
+          vcr('space/locale/find') do
             space = subject.find(space_id)
             expect(space.id).to eql space_id
             expect(space.default_locale).to eql 'en-US'
@@ -148,6 +148,15 @@ module Contentful
           vcr('space/content_type/all') do
             content_types = subject.find(space_id).content_types.all
             expect(content_types).to be_kind_of Contentful::Management::Array
+          end
+        end
+      end
+
+      describe '#default_locale' do
+        it 'can set default locales from space locales on already existing spaces' do
+          vcr('space/locale/find_other_locale') do
+            space = subject.find(space_id)
+            expect(space.default_locale).to eql 'de-DE'
           end
         end
       end


### PR DESCRIPTION
Fixes #60 

```ruby
[1] pry(main)> require 'contentful/management'
=> true
[2] pry(main)> client = Contentful::Management::Client.new("your_token")
=> #<Contentful::Management::Client:0x007ff89c9d8b08
 @access_token="your_token",
 @configuration=
  {:api_url=>"api.contentful.com",
   :api_version=>"1",
   :secure=>true,
   :default_locale=>"en-US",
   :gzip_encoded=>false,
   :logger=>false,
   :log_level=>1,
   :raise_errors=>false},
 @dynamic_entry_cache={},
 @logger=false>
[3] pry(main)> Contentful::Management::Space.all.each do |space|
[3] pry(main)*   puts space.default_locale
[3] pry(main)* end
en-US
de-DE
```