### PR TITLE
Bump HTTP gem to ~v1.0

### DIFF
--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '~> 0.8'
+  spec.add_dependency 'http', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
We're in need of access to the Twitter gem, which uses ~v1.0 of the HTTP gem.

We've looked at http's changelog and noticed that they've only removed functionality ([here](https://github.com/httprb/http/blob/master/CHANGES.md#100-2015-12-25) and [here](https://github.com/httprb/http/blob/master/CHANGES.md#090-2015-07-23)). but that they aren't implemented features in this gem.