### PR TITLE
Dont set content-length header to 0

### DIFF
--- a/lib/contentful/management/client.rb
+++ b/lib/contentful/management/client.rb
@@ -31,7 +31,7 @@ module Contentful
       extend Contentful::Management::HTTPClient
 
       attr_reader :access_token, :configuration, :logger
-      attr_accessor :organization_id, :version, :zero_length, :content_type_id, :dynamic_entry_cache
+      attr_accessor :organization_id, :version, :content_type_id, :dynamic_entry_cache
 
       # Default configuration for Contentful::Management::Client
       DEFAULT_CONFIGURATION = {
@@ -437,11 +437,6 @@ module Contentful
       end
 
       # @private
-      def zero_length_header
-        Hash['Content-Length', 0]
-      end
-
-      # @private
       def accept_encoding_header(encoding)
         Hash['Accept-Encoding', encoding]
       end
@@ -455,7 +450,6 @@ module Contentful
         headers.merge! api_version_header
         headers.merge! organization_header(organization_id) if organization_id
         headers.merge! version_header(version) if version
-        headers.merge! zero_length_header if zero_length
         headers.merge! content_type_header(content_type_id) if content_type_id
         headers.merge! accept_encoding_header('gzip') if gzip_encoded
 

--- a/lib/contentful/management/request.rb
+++ b/lib/contentful/management/request.rb
@@ -17,7 +17,6 @@ module Contentful
 
         case query
         when Hash
-          @client.zero_length = query.empty?
           @query = normalize_query(query) if query && !query.empty?
         else
           @query = query


### PR DESCRIPTION
Fixes https://github.com/contentful/contentful-management.rb/issues/124

This was causing uploads to the uploads API to be rejected as the endpoint enforces that the value for the `content-length` header is greater than 0:

```
curl -i -X POST \
-H "Content-Type: application/octet-stream" \
-H "Authorization: Bearer $CMA_TOKEN_PROD" \
--data-binary "@/path/to/image.png" \
-H "Content-Length: 0" \
https://upload.contentful.com/spaces/<space_id>/uploads

HTTP/1.1 400 Bad Request
Access-Control-Allow-Headers: Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Etag
cache-control: no-cache
Content-Type: text/html; charset=utf-8
Date: Fri, 28 Jul 2017 14:47:42 GMT
Server: Contentful
Strict-Transport-Security: max-age=15768000
vary: accept-encoding
X-Content-Type-Options: nosniff
X-Contentful-Request-Id: f0426ee583f94a825089b6b669ed7336
Content-Length: 131
Connection: keep-alive

{
  "sys": {
    "type": "Error",
    "id": "BadRequest"
  },
  "message": "The \"Content-Length\" header must be greater than 0"
}%
```
 Aside from that, there's no need to manually set this header since it's handled by the underlying HTTP library.

We should also handle this error more gracefully like other client requests. I'll try submit a PR over the weekend


