### PR TITLE
Fix #save method

### DIFF
--- a/lib/contentful/management/api_key.rb
+++ b/lib/contentful/management/api_key.rb
@@ -59,6 +59,19 @@ module Contentful
       def preview_api_key
         client.preview_api_keys(space.id).find(properties[:preview_api_key].id)
       end
+
+      protected
+
+      def query_attributes(attributes)
+        self.class.create_attributes(
+          nil,
+          {
+            name: name,
+            description: description,
+            environments: environments
+          }.merge(attributes)
+        )
+      end
     end
   end
 end

--- a/lib/contentful/management/asset.rb
+++ b/lib/contentful/management/asset.rb
@@ -116,9 +116,9 @@ module Contentful
       end
 
       def query_attributes(attributes)
-        self.title = attributes[:title] if attributes[:title]
-        self.description = attributes[:description] if attributes[:description]
-        self.file = attributes[:file] if attributes[:file]
+        self.title = attributes[:title] || title
+        self.description = attributes[:description] || description
+        self.file = attributes[:file] || file
 
         { fields: fields_for_query }
       end

--- a/lib/contentful/management/editor_interface.rb
+++ b/lib/contentful/management/editor_interface.rb
@@ -85,7 +85,11 @@ module Contentful
       end
 
       def query_attributes(attributes)
-        attributes.each_with_object({}) { |(k, v), result| result[k.to_sym] = v }
+        {
+          controls: controls
+        }.merge(
+          attributes.each_with_object({}) { |(k, v), result| result[k.to_sym] = v }
+        )
       end
     end
   end

--- a/lib/contentful/management/environment.rb
+++ b/lib/contentful/management/environment.rb
@@ -147,6 +147,14 @@ module Contentful
       def refresh_find
         self.class.find(client, space.id, id)
       end
+
+      protected
+
+      def query_attributes(attributes)
+        {
+          name: name
+        }.merge(attributes)
+      end
     end
   end
 end

--- a/lib/contentful/management/locale.rb
+++ b/lib/contentful/management/locale.rb
@@ -32,7 +32,14 @@ module Contentful
       protected
 
       def query_attributes(attributes)
-        attributes.each_with_object({}) { |(k, v), result| result[k.to_sym] = v }
+        {
+          name: name,
+          code: code,
+          optional: optional,
+          fallbackCode: fallback_code
+        }.merge(
+          attributes.each_with_object({}) { |(k, v), result| result[k.to_sym] = v }
+        )
       end
     end
   end

--- a/lib/contentful/management/resource/refresher.rb
+++ b/lib/contentful/management/resource/refresher.rb
@@ -12,7 +12,8 @@ module Contentful
 
         # @private
         def refresh_find
-          self.class.find(client, space.id, environment_id, id)
+          return self.class.find(client, space.id, environment_id, id) if environment_id
+          self.class.find(client, space.id, id)
         end
 
         # @private

--- a/lib/contentful/management/role.rb
+++ b/lib/contentful/management/role.rb
@@ -48,7 +48,14 @@ module Contentful
       protected
 
       def query_attributes(attributes)
-        attributes.each_with_object({}) { |(k, v), result| result[k.to_sym] = v }
+        {
+          name: name,
+          description: description,
+          permissions: permissions,
+          policies: policies
+        }.merge(
+          attributes.each_with_object({}) { |(k, v), result| result[k.to_sym] = v }
+        )
       end
 
       # @private

--- a/lib/contentful/management/space.rb
+++ b/lib/contentful/management/space.rb
@@ -166,6 +166,12 @@ module Contentful
 
       protected
 
+      def query_attributes(attributes)
+        {
+          name: name
+        }.merge(attributes)
+      end
+
       def refresh_find
         self.class.find(client, id)
       end

--- a/lib/contentful/management/webhook.rb
+++ b/lib/contentful/management/webhook.rb
@@ -74,7 +74,18 @@ module Contentful
       protected
 
       def query_attributes(attributes)
-        self.class.create_attributes(nil, attributes)
+        self.class.create_attributes(
+          nil,
+          {
+            url: url,
+            name: name,
+            topics: topics,
+            headers: headers,
+            httpBasicUsername: http_basic_username,
+            filters: filters,
+            transformation: transformation
+          }.merge(attributes)
+        )
       end
     end
   end

--- a/spec/fixtures/vcr_cassettes/api_key/issue_189.yml
+++ b/spec/fixtures/vcr_cassettes/api_key/issue_189.yml
@@ -1,0 +1,476 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/api_keys/5rjsSfZUvHJnWBDkbcCsem
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:29:57 GMT
+      Etag:
+      - W/"ee4064a28cc997b3d479492a6f74b26d"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 1a925fe051f4b74bbf151b50a14a91a6
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '1160'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=baPFJsTWwWXeoWoUCkbyDtRjo1wAAAAA7Kovsj9OUSXsUCzoeAko1A==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=8gi/C6asIRhEx1XqYMlkBAAAAABJsJAkAt1ahydRN/RUSQLx; path=/; Domain=.contentful.com
+      - visid_incap_673446=roXiP+VsR42ppuS/wI0Od9Rjo1wAAAAAQUIPAAAAAACv3iML2eglTfkNRnifG/rz;
+        expires=Wed, 01 Apr 2020 05:58:50 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 12-468673-468674 NNNN CT(114 114 0) RT(1554211796039 57) q(0 0 3 -1) r(4 4)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"test - updated",
+          "description":"",
+          "accessToken":"a53de8ab24af833c7352f2b3262591b40b4765c42a288e1f54d374620a7bd619",
+          "policies":[
+            {
+              "effect":"allow",
+              "actions":"all"
+            }
+          ],
+          "sys":{
+            "type":"ApiKey",
+            "id":"5rjsSfZUvHJnWBDkbcCsem",
+            "version":4,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-09-17T09:12:17Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2018-09-17T09:22:09Z"
+          },
+          "environments":[
+            {
+              "sys":{
+                "id":"testing",
+                "type":"Link",
+                "linkType":"Environment"
+              }
+            },
+            {
+              "sys":{
+                "id":"master",
+                "type":"Link",
+                "linkType":"Environment"
+              }
+            }
+          ],
+          "preview_api_key":{
+            "sys":{
+              "type":"Link",
+              "linkType":"PreviewApiKey",
+              "id":"5rkieiBVQBhmVPfgrfTxA6"
+            }
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:29:57 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/api_keys/5rjsSfZUvHJnWBDkbcCsem
+    body:
+      encoding: UTF-8
+      string: '{"name":"test - updated 2","description":"","environments":["#<Contentful::Management::Link:0x00007fa74690dba8>","#<Contentful::Management::Link:0x00007fa74690d018>"]}'
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '4'
+      Version:
+      - '4'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:29:57 GMT
+      Etag:
+      - W/"82ea9f73bb585a5686f43861e04ee0a9"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35998'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '8'
+      X-Contentful-Request-Id:
+      - 22ba926216763c4525b94b0064865fa6
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '1047'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=Pl2FOkKQUnDwoWoUCkbyDtVjo1wAAAAAJsiBB2wfMR7tFhAOy3eCjA==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=CHfkdKUEtyZGK7RHYMlkBAAAAABVBnkYKRhDc+11XV2/V9Nt; path=/; Domain=.contentful.com
+      - visid_incap_673446=6OZjLktRQjCpW2bkGQ64XtVjo1wAAAAAQUIPAAAAAAD9oeNTrhN3FztQM8rablqG;
+        expires=Wed, 01 Apr 2020 05:58:22 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 4-1112978-1112979 NNNN CT(107 106 0) RT(1554211796564 51) q(0 0 2 -1) r(4
+        4) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"test - updated 2",
+          "description":"",
+          "accessToken":"a53de8ab24af833c7352f2b3262591b40b4765c42a288e1f54d374620a7bd619",
+          "policies":[
+            {
+              "effect":"allow",
+              "actions":"all"
+            }
+          ],
+          "sys":{
+            "type":"ApiKey",
+            "id":"5rjsSfZUvHJnWBDkbcCsem",
+            "version":5,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-09-17T09:12:17Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:29:57Z"
+          },
+          "environments":[
+            {
+              "sys":{
+                "id":"master",
+                "type":"Link",
+                "linkType":"Environment"
+              }
+            }
+          ],
+          "preview_api_key":{
+            "sys":{
+              "type":"Link",
+              "linkType":"PreviewApiKey",
+              "id":"5rkieiBVQBhmVPfgrfTxA6"
+            }
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:29:57 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/api_keys/5rjsSfZUvHJnWBDkbcCsem
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:29:58 GMT
+      Etag:
+      - W/"82ea9f73bb585a5686f43861e04ee0a9"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 7f277f2afca4b7ef050a663d82b6bde8
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '1047'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=lWeSYMEmvlQEomoUCkbyDtVjo1wAAAAArGE5hHQc6mtAiNmohmvOog==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=np9Ffa4WYUgEV1zMYMlkBAAAAAB5Emvv9J5iQZvMKsIsEYgl; path=/; Domain=.contentful.com
+      - visid_incap_673446=NthvU3CcRT6ZpqTsOU5H6NVjo1wAAAAAQUIPAAAAAAB5bEpQFqHTkxucGLY+j/dF;
+        expires=Wed, 01 Apr 2020 05:58:22 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 3-927481-927482 NNNN CT(113 113 0) RT(1554211797082 52) q(0 0 2 -1) r(4 4)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"test - updated 2",
+          "description":"",
+          "accessToken":"a53de8ab24af833c7352f2b3262591b40b4765c42a288e1f54d374620a7bd619",
+          "policies":[
+            {
+              "effect":"allow",
+              "actions":"all"
+            }
+          ],
+          "sys":{
+            "type":"ApiKey",
+            "id":"5rjsSfZUvHJnWBDkbcCsem",
+            "version":5,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-09-17T09:12:17Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:29:57Z"
+          },
+          "environments":[
+            {
+              "sys":{
+                "id":"master",
+                "type":"Link",
+                "linkType":"Environment"
+              }
+            }
+          ],
+          "preview_api_key":{
+            "sys":{
+              "type":"Link",
+              "linkType":"PreviewApiKey",
+              "id":"5rkieiBVQBhmVPfgrfTxA6"
+            }
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:29:58 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/environment/issue_189.yml
+++ b/spec/fixtures/vcr_cassettes/environment/issue_189.yml
@@ -1,0 +1,418 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/environments/testing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:32:30 GMT
+      Etag:
+      - W/"efb427da4c64de61fd8bde26734945d1"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 502d488b15f3bcce426010a961126e4c
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '690'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=6LNMAhIQmBL9vmoUCkbyDm1ko1wAAAAA/Mku1mhh1/Dtrw6fNMy5pA==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=RLMIC6njYh5pvmNIYMlkBAAAAADdncYQktKzX2qlIsv7+keD; path=/; Domain=.contentful.com
+      - visid_incap_673446=T+IeodZqR0eRzuO/rjzGqm1ko1wAAAAAQUIPAAAAAAAgww8NzcEB35BTC58V0qwA;
+        expires=Wed, 01 Apr 2020 05:58:41 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 14-1277974-1277980 NNNN CT(110 110 0) RT(1554211948829 56) q(0 0 3 -1) r(4
+        4) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"testing",
+          "sys":{
+            "type":"Environment",
+            "id":"testing",
+            "version":6,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "status":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Status",
+                "id":"ready"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-02-27T10:19:01Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2018-02-27T10:19:04Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:32:29 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/environments/testing
+    body:
+      encoding: UTF-8
+      string: '{"name":"testing 2"}'
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '6'
+      Version:
+      - '6'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:32:30 GMT
+      Etag:
+      - W/"b5f8d465c58fdb2d4de7e800b00f1eaa"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35998'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '8'
+      X-Contentful-Request-Id:
+      - decca8b7b1feb8049b4ab934dc7ec9df
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '692'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=bvr5O4rBJkEbv2oUCkbyDm1ko1wAAAAAAWKfvmk91Xcrdb5rBWuxSQ==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=iyoFbxrp7FX472siYMlkBAAAAAC+cvsSmtTd21tfVrsk6ISe; path=/; Domain=.contentful.com
+      - visid_incap_673446=Krj3Vrd+R/S9E5IcCikqKG1ko1wAAAAAQUIPAAAAAAB8+SfOI41EUL/rE/OeKYP4;
+        expires=Wed, 01 Apr 2020 05:58:41 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 13-703744-703745 NNNN CT(111 112 0) RT(1554211949297 53) q(0 0 2 -1) r(5 5)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"testing 2",
+          "sys":{
+            "type":"Environment",
+            "id":"testing",
+            "version":7,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "status":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Status",
+                "id":"ready"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-02-27T10:19:01Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:32:30Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:32:30 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/environments/testing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:32:31 GMT
+      Etag:
+      - W/"b5f8d465c58fdb2d4de7e800b00f1eaa"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - b5ac2e8867d263c7b74a77360a5b1402
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '692'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=k+YaP/pkiSQtv2oUCkbyDm5ko1wAAAAAKkEMcH8VCp6csLuvncT2Fw==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=ks5WKUyRliUTXlakYMlkBAAAAAACbD2WwCetGlqTcYesy44+; path=/; Domain=.contentful.com
+      - visid_incap_673446=YhAAI+voTZGG97cgP92+Vm5ko1wAAAAAQUIPAAAAAADUz8RLa3j0pm1dFGh4MBFl;
+        expires=Wed, 01 Apr 2020 05:58:42 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 5-1460327-1460329 NNNN CT(110 110 0) RT(1554211949878 60) q(0 0 2 -1) r(4
+        4) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"testing 2",
+          "sys":{
+            "type":"Environment",
+            "id":"testing",
+            "version":7,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "status":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Status",
+                "id":"ready"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-02-27T10:19:01Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:32:30Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:32:30 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/locale/issue_189.yml
+++ b/spec/fixtures/vcr_cassettes/locale/issue_189.yml
@@ -1,0 +1,438 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/environments/master/locales/4brXbuf0CeMWo4vlIfWe0q
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 12:24:56 GMT
+      Etag:
+      - W/"a9012413581ea6c1772a124efbf5cf85"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 64c570c532916461862179b64b43c88d
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '873'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=/IwQQC4ptkTo32cUCkbyDpdUo1wAAAAAT4hC3eOgKgcivRVG7x7/Pw==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=v36AQFwY+wvNlpDJYMlkBAAAAACInLUEB/KEaUUqFceQhmu9; path=/; Domain=.contentful.com
+      - visid_incap_673446=X7mOb3k4R+u95aKplxRyx5dUo1wAAAAAQUIPAAAAAADKoqfaC7v8y9cIALXWQk2y;
+        expires=Wed, 01 Apr 2020 05:58:42 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 5-1233589-1233594 NNNN CT(122 123 0) RT(1554207895529 60) q(0 0 3 -1) r(4
+        4) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"foo",
+          "internal_code":"bar",
+          "code":"bar",
+          "fallbackCode":"en-US",
+          "default":false,
+          "contentManagementApi":true,
+          "contentDeliveryApi":true,
+          "optional":false,
+          "sys":{
+            "type":"Locale",
+            "id":"4brXbuf0CeMWo4vlIfWe0q",
+            "version":1,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "environment":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Environment",
+                "id":"master"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-06-13T09:39:05Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2018-06-13T09:39:05Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 12:24:56 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/environments/master/locales/4brXbuf0CeMWo4vlIfWe0q
+    body:
+      encoding: UTF-8
+      string: '{"name":"foo","code":"bar2","optional":false,"fallbackCode":"en-US"}'
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '1'
+      Version:
+      - '1'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 12:24:57 GMT
+      Etag:
+      - W/"0c4ca2cd90d6707f55c3fba23ba0dea4"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - d185ee3f73d0b4798d80b2fe9eb9b29b
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '874'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=fT1nIz5KewMH4GcUCkbyDphUo1wAAAAAc1l8A/IvENXxr6lCvjAWlQ==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=JIiwAr6cm3uylyZLYMlkBAAAAADExZvdSAoEBgk+QgjJMZVx; path=/; Domain=.contentful.com
+      - visid_incap_673446=CwRhQ/uVRV6v1HgXHVSyyJhUo1wAAAAAQUIPAAAAAABuZGyQBHAJg42J9q+NqsnQ;
+        expires=Wed, 01 Apr 2020 05:58:50 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 12-387879-387935 NNNN CT(94 191 0) RT(1554207896139 58) q(0 0 3 -1) r(5 5)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"foo",
+          "internal_code":"bar",
+          "code":"bar2",
+          "fallbackCode":"en-US",
+          "default":false,
+          "contentManagementApi":true,
+          "contentDeliveryApi":true,
+          "optional":false,
+          "sys":{
+            "type":"Locale",
+            "id":"4brXbuf0CeMWo4vlIfWe0q",
+            "version":2,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "environment":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Environment",
+                "id":"master"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-06-13T09:39:05Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T12:24:57Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 12:24:56 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/environments/master/locales/4brXbuf0CeMWo4vlIfWe0q
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 12:24:58 GMT
+      Etag:
+      - W/"0c4ca2cd90d6707f55c3fba23ba0dea4"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 5eb104825c3b441dcc1f29e4879e326a
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '874'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=FeVYEJ6nNl0S4GcUCkbyDplUo1wAAAAApp9/o3MD+/CTysmYCcDb7Q==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=p7A8aq7RHV29GO9MYMlkBAAAAACh/gkcetLRPK1S4hCaQjK2; path=/; Domain=.contentful.com
+      - visid_incap_673446=mDXaVp6xR+ia4ENGk9U0cJlUo1wAAAAAQUIPAAAAAABzi4ks4m+XVJ1gsGEcQlMZ;
+        expires=Wed, 01 Apr 2020 05:58:22 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 3-802902-802905 NNNN CT(97 97 0) RT(1554207896791 51) q(0 0 2 -1) r(3 3) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"foo",
+          "internal_code":"bar",
+          "code":"bar2",
+          "fallbackCode":"en-US",
+          "default":false,
+          "contentManagementApi":true,
+          "contentDeliveryApi":true,
+          "optional":false,
+          "sys":{
+            "type":"Locale",
+            "id":"4brXbuf0CeMWo4vlIfWe0q",
+            "version":2,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "environment":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Environment",
+                "id":"master"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-06-13T09:39:05Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T12:24:57Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 12:24:57 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/roles/issue_189.yml
+++ b/spec/fixtures/vcr_cassettes/roles/issue_189.yml
@@ -1,0 +1,689 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/roles/1NzxmNIjPtzpJae5OL1m4u
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:35:38 GMT
+      Etag:
+      - W/"649732b229dc01625bd6260e66b6e307"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 2e42b9ec5f31ad2742bac56334f0e85b
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '2208'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=Rtf7I6HgZzO+4GoUCkbyDillo1wAAAAAhIM4iVao9GyBDzcwcUXZBQ==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=85p3PL2PxRUIYsNoYMlkBAAAAAB15XyorE1pLnrbpLI0ReJh; path=/; Domain=.contentful.com
+      - visid_incap_673446=O5IqvlB0QeSadrFcGaiKtSllo1wAAAAAQUIPAAAAAAASI+w+OBtoHSOktLQOwo8M;
+        expires=Wed, 01 Apr 2020 05:58:50 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 12-483033-483036 NNNN CT(101 101 0) RT(1554212137287 54) q(0 0 2 -1) r(3 3)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"Translator 1",
+          "description":"Allows editing of localized fields in the specified language",
+          "policies":[
+            {
+              "effect":"allow",
+              "actions":[
+                "read"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Entry"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "read"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Asset"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "update"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Entry"
+                    ]
+                  },
+                  {
+                    "paths":[
+                      {
+                        "doc":"fields.%.%"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "update"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Asset"
+                    ]
+                  },
+                  {
+                    "paths":[
+                      {
+                        "doc":"fields.%.%"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "permissions":{
+            "ContentModel":[
+              "read"
+            ],
+            "Settings":[],
+            "ContentDelivery":[],
+            "Environments":[]
+          },
+          "sys":{
+            "type":"Role",
+            "id":"1NzxmNIjPtzpJae5OL1m4u",
+            "version":0,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2017-03-02T18:30:27Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2017-03-02T18:30:27Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:35:38 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/roles/1NzxmNIjPtzpJae5OL1m4u
+    body:
+      encoding: UTF-8
+      string: '{"name":"Translator - Updated","description":"Allows editing of localized
+        fields in the specified language","permissions":{"ContentModel":["read"],"Settings":[],"ContentDelivery":[],"Environments":[]},"policies":[{"effect":"allow","actions":["read"],"constraint":{"and":[{"equals":[{"doc":"sys.type"},"Entry"]}]}},{"effect":"allow","actions":["read"],"constraint":{"and":[{"equals":[{"doc":"sys.type"},"Asset"]}]}},{"effect":"allow","actions":["update"],"constraint":{"and":[{"equals":[{"doc":"sys.type"},"Entry"]},{"paths":[{"doc":"fields.%.%"}]}]}},{"effect":"allow","actions":["update"],"constraint":{"and":[{"equals":[{"doc":"sys.type"},"Asset"]},{"paths":[{"doc":"fields.%.%"}]}]}}]}'
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '0'
+      Version:
+      - '0'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:35:39 GMT
+      Etag:
+      - W/"f76550f5b37635a7e5435fe620d77f99"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - d986a015d59a3df7e1bea44c78f37f42
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '2216'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=PNqJCOCz8GfT4GoUCkbyDiplo1wAAAAAb0Iaw6wTAK++ERR14+XsCw==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=cqE4ebqQzxPDsk+IYMlkBAAAAABO5Ut1Ows5+YS6rHrQzdD+; path=/; Domain=.contentful.com
+      - visid_incap_673446=fz2V25ayR7eD15IcAgYKtyplo1wAAAAAQUIPAAAAAACAi1Nf0c1pimEVwFgddp8J;
+        expires=Wed, 01 Apr 2020 05:58:41 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 6-744059-744060 NNNN CT(101 103 0) RT(1554212137777 54) q(0 0 2 -1) r(4 4)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"Translator - Updated",
+          "description":"Allows editing of localized fields in the specified language",
+          "policies":[
+            {
+              "effect":"allow",
+              "actions":[
+                "read"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Entry"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "read"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Asset"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "update"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Entry"
+                    ]
+                  },
+                  {
+                    "paths":[
+                      {
+                        "doc":"fields.%.%"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "update"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Asset"
+                    ]
+                  },
+                  {
+                    "paths":[
+                      {
+                        "doc":"fields.%.%"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "permissions":{
+            "ContentModel":[
+              "read"
+            ],
+            "Settings":[],
+            "ContentDelivery":[],
+            "Environments":[]
+          },
+          "sys":{
+            "type":"Role",
+            "id":"1NzxmNIjPtzpJae5OL1m4u",
+            "version":1,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2017-03-02T18:30:27Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:35:39Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:35:38 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/roles/1NzxmNIjPtzpJae5OL1m4u
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:35:39 GMT
+      Etag:
+      - W/"f76550f5b37635a7e5435fe620d77f99"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35998'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '8'
+      X-Contentful-Request-Id:
+      - 0ed59213ef7046c61f821582b26d8e77
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '2216'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=kO9Meu78BUHs4GoUCkbyDiplo1wAAAAAt0A7bq4DxQMGDjQ4V/8J6g==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=9Cb4NKm7wBE6LgJ6YMlkBAAAAAB9fUfGXU4/IpHpXSrWtoV+; path=/; Domain=.contentful.com
+      - visid_incap_673446=FmPqGnIoSyeUDTVz+uzGfiplo1wAAAAAQUIPAAAAAACkm9rU5qbeFqVX1rdLfSUR;
+        expires=Wed, 01 Apr 2020 05:58:41 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 7-1239286-1239291 NNNN CT(126 126 0) RT(1554212138260 54) q(0 0 2 -1) r(4
+        4) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"Translator - Updated",
+          "description":"Allows editing of localized fields in the specified language",
+          "policies":[
+            {
+              "effect":"allow",
+              "actions":[
+                "read"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Entry"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "read"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Asset"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "update"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Entry"
+                    ]
+                  },
+                  {
+                    "paths":[
+                      {
+                        "doc":"fields.%.%"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "effect":"allow",
+              "actions":[
+                "update"
+              ],
+              "constraint":{
+                "and":[
+                  {
+                    "equals":[
+                      {
+                        "doc":"sys.type"
+                      },
+                      "Asset"
+                    ]
+                  },
+                  {
+                    "paths":[
+                      {
+                        "doc":"fields.%.%"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "permissions":{
+            "ContentModel":[
+              "read"
+            ],
+            "Settings":[],
+            "ContentDelivery":[],
+            "Environments":[]
+          },
+          "sys":{
+            "type":"Role",
+            "id":"1NzxmNIjPtzpJae5OL1m4u",
+            "version":1,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2017-03-02T18:30:27Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:35:39Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:35:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/space/issue_189.yml
+++ b/spec/fixtures/vcr_cassettes/space/issue_189.yml
@@ -1,0 +1,376 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/no8f22w4syte
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - no8f22w4syte
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:38:01 GMT
+      Etag:
+      - W/"10014eafa25030a6ced3534846716cdf"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 465eb5706297c2815c1e959a877824c4
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '446'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=mHHJX+SpkAbj+2oUCkbyDrhlo1wAAAAASyLJd/Wn0cK180NsDVE3BQ==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=KPescHEmRyqZuKmWYMlkBAAAAACT4oEEg+w5q5/dFgd1HI6u; path=/; Domain=.contentful.com
+      - visid_incap_673446=VSfAGOQRRXuXCcVOoTphWbhlo1wAAAAAQUIPAAAAAAAW+m3Sirh/SBHT8/cEbGqn;
+        expires=Wed, 01 Apr 2020 05:58:41 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 14-1296528-1296534 NNNN CT(117 117 0) RT(1554212280316 58) q(0 0 3 -1) r(4
+        4) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"foo",
+          "sys":{
+            "type":"Space",
+            "id":"no8f22w4syte",
+            "version":1,
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2017-02-16T12:33:43Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2017-02-16T12:33:43Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:38:01 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/no8f22w4syte
+    body:
+      encoding: UTF-8
+      string: '{"name":"bar"}'
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '1'
+      Version:
+      - '1'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - no8f22w4syte
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:38:02 GMT
+      Etag:
+      - W/"bc48cb7f31bbcd44db7493f0f394f148"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 2d2d7aca3e8afe6a8e2c8325b3629bd7
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '446'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=GJvEQYPSTg4D/GoUCkbyDrllo1wAAAAAxCSykB6sAdwdsx5cWJg/1g==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=jMPodT1zQlpEZtA9YMlkBAAAAAAgTbIKC2TmVZXwcRmvNcTG; path=/; Domain=.contentful.com
+      - visid_incap_673446=7PREQ+wuRgu1JY2yQgY/BLllo1wAAAAAQUIPAAAAAAB4Sq/InAfTBH6FUSZcoYAE;
+        expires=Wed, 01 Apr 2020 05:58:50 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 8-164200-164202 NNNN CT(115 116 0) RT(1554212280818 55) q(0 0 3 -1) r(5 5)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"bar",
+          "sys":{
+            "type":"Space",
+            "id":"no8f22w4syte",
+            "version":2,
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2017-02-16T12:33:43Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:38:02Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:38:02 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/no8f22w4syte
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - no8f22w4syte
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 13:38:02 GMT
+      Etag:
+      - W/"bc48cb7f31bbcd44db7493f0f394f148"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35998'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '8'
+      X-Contentful-Request-Id:
+      - '08697562ca1ec604359848093ea2ce58'
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '446'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=fRaMSIgSEmsy/GoUCkbyDrllo1wAAAAANzYYIt2ucjbW68PWvy/+5w==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=tbNvHEmndSNSTC+HYMlkBAAAAACZ+GnaTX1o9vsIEvnAj4xE; path=/; Domain=.contentful.com
+      - visid_incap_673446=ufwe7hZRSSmsb5U3oQAV0bllo1wAAAAAQUIPAAAAAACtRCf2yIHqzCtViLjf6GWn;
+        expires=Wed, 01 Apr 2020 05:58:42 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 5-1476850-1476853 NNNN CT(106 107 0) RT(1554212281460 50) q(0 0 2 -1) r(3
+        3) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"bar",
+          "sys":{
+            "type":"Space",
+            "id":"no8f22w4syte",
+            "version":2,
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2017-02-16T12:33:43Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T13:38:02Z"
+          }
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 13:38:02 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/webhook/issue_189.yml
+++ b/spec/fixtures/vcr_cassettes/webhook/issue_189.yml
@@ -1,0 +1,448 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/webhook_definitions/0Kgjs0DQizupIbmSHcyaFM
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 12:18:40 GMT
+      Etag:
+      - W/"061d44a61a20d842c7133f3e49833e58"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 737341b82903eb2c53cf0cb809fe79d7
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '880'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=KvcJZIGtlAZun2cUCkbyDh9To1wAAAAAXhX1b2qhOTtyg0Saptd3gg==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=7Hune9fdYnqPNBi/YMlkBAAAAAA1nfwLUPCeyfm7bFmhNs0z; path=/; Domain=.contentful.com
+      - visid_incap_673446=bf9x+DXNTWKGOXyHBx2r9B9To1wAAAAAQUIPAAAAAACmXBBBnr3cNRN6hnKcnC9j;
+        expires=Wed, 01 Apr 2020 05:58:22 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 3-788748-788750 NNNN CT(124 126 0) RT(1554207519098 54) q(0 0 3 -1) r(4 4)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"test_ruby_filters",
+          "url":"https://www.example.com",
+          "httpBasicUsername":null,
+          "topics":[
+            "Entry.*"
+          ],
+          "filters":[
+            {
+              "equals":[
+                {
+                  "doc":"sys.environment.sys.id"
+                },
+                "some-env-id"
+              ]
+            }
+          ],
+          "transformation":null,
+          "sys":{
+            "type":"WebhookDefinition",
+            "id":"0Kgjs0DQizupIbmSHcyaFM",
+            "version":2,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-08-17T12:00:45Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T12:18:31Z"
+          },
+          "headers":[]
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 12:18:39 GMT
+- request:
+    method: put
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/webhook_definitions/0Kgjs0DQizupIbmSHcyaFM
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://www.example2.com","name":"test_ruby_filters","topics":["Entry.*"],"headers":[],"httpBasicUsername":null,"filters":[{"equals":[{"doc":"sys.environment.sys.id"},"some-env-id"]}],"transformation":null}'
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      X-Contentful-Version:
+      - '2'
+      Version:
+      - '2'
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 12:18:41 GMT
+      Etag:
+      - W/"d3da0b7217c181bef71a1d18aee438d3"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35998'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '8'
+      X-Contentful-Request-Id:
+      - 052451e4e59f358bba44c40a1052be37
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '881'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=fk31ElvHQDCSn2cUCkbyDiBTo1wAAAAALmcMOgx9vOsitbsvc/stRQ==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=DHFBKrFhMHLhQRzRYMlkBAAAAACPxONuTzl0O+h21rmWBOyu; path=/; Domain=.contentful.com
+      - visid_incap_673446=YUy36j+/QQuy901CHaxDDyBTo1wAAAAAQUIPAAAAAABF23BThcUdgvmnK2MwNuOZ;
+        expires=Wed, 01 Apr 2020 05:58:22 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 4-938753-938756 NNNN CT(116 116 0) RT(1554207519704 56) q(0 0 2 -1) r(5 5)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"test_ruby_filters",
+          "url":"https://www.example2.com",
+          "httpBasicUsername":null,
+          "topics":[
+            "Entry.*"
+          ],
+          "filters":[
+            {
+              "equals":[
+                {
+                  "doc":"sys.environment.sys.id"
+                },
+                "some-env-id"
+              ]
+            }
+          ],
+          "transformation":null,
+          "sys":{
+            "type":"WebhookDefinition",
+            "id":"0Kgjs0DQizupIbmSHcyaFM",
+            "version":3,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-08-17T12:00:45Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T12:18:41Z"
+          },
+          "headers":[]
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 12:18:40 GMT
+- request:
+    method: get
+    uri: https://api.contentful.com/spaces/facgnwwgj5fe/webhook_definitions/0Kgjs0DQizupIbmSHcyaFM
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Contentful-User-Agent:
+      - sdk contentful-management.rb/2.8.0; platform ruby/2.5.3; os macOS/16;
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Connection:
+      - close
+      Host:
+      - api.contentful.com
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature,X-Contentful-Source-Environment,X-Contentful-Team
+      Access-Control-Allow-Methods:
+      - DELETE,GET,HEAD,POST,PUT,OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Etag
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0
+      Cf-Organization-Id:
+      - 4SsuxQCaMaemfIms52Jr8s
+      Cf-Space-Id:
+      - facgnwwgj5fe
+      Content-Type:
+      - application/vnd.contentful.management.v1+json
+      Contentful-Api:
+      - cma
+      Date:
+      - Tue, 02 Apr 2019 12:18:41 GMT
+      Etag:
+      - W/"d3da0b7217c181bef71a1d18aee438d3"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Contentful
+      Strict-Transport-Security:
+      - max-age=15768000
+      X-Content-Type-Options:
+      - nosniff
+      X-Contentful-Ratelimit-Hour-Limit:
+      - '36000'
+      X-Contentful-Ratelimit-Hour-Remaining:
+      - '35999'
+      X-Contentful-Ratelimit-Reset:
+      - '0'
+      X-Contentful-Ratelimit-Second-Limit:
+      - '10'
+      X-Contentful-Ratelimit-Second-Remaining:
+      - '9'
+      X-Contentful-Request-Id:
+      - 37eeb792a267300d8fdcea5aeb6e2f6e
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - ALLOWALL
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '881'
+      Connection:
+      - Close
+      Set-Cookie:
+      - incap_ses_1077_673446=qREVZfhd+jvBn2cUCkbyDiBTo1wAAAAACtZ3lPpTHbZotYwZaXHPpw==;
+        path=/; Domain=.contentful.com
+      - nlbi_673446=OTxMHxopPAYYwDi5YMlkBAAAAADWqK+S/mLqzNeAkzFgdBwa; path=/; Domain=.contentful.com
+      - visid_incap_673446=yWG9UjARRAytwWoB52fWoCBTo1wAAAAAQUIPAAAAAAC2Vq95g3X0T8/Mqh5GEADY;
+        expires=Wed, 01 Apr 2020 05:58:46 GMT; path=/; Domain=.contentful.com
+      X-Iinfo:
+      - 11-280725-280730 NNNN CT(118 118 0) RT(1554207520316 53) q(0 0 3 -1) r(4 4)
+        U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: |+
+        {
+          "name":"test_ruby_filters",
+          "url":"https://www.example2.com",
+          "httpBasicUsername":null,
+          "topics":[
+            "Entry.*"
+          ],
+          "filters":[
+            {
+              "equals":[
+                {
+                  "doc":"sys.environment.sys.id"
+                },
+                "some-env-id"
+              ]
+            }
+          ],
+          "transformation":null,
+          "sys":{
+            "type":"WebhookDefinition",
+            "id":"0Kgjs0DQizupIbmSHcyaFM",
+            "version":3,
+            "space":{
+              "sys":{
+                "type":"Link",
+                "linkType":"Space",
+                "id":"facgnwwgj5fe"
+              }
+            },
+            "createdBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "createdAt":"2018-08-17T12:00:45Z",
+            "updatedBy":{
+              "sys":{
+                "type":"Link",
+                "linkType":"User",
+                "id":"4SejVrWT96dvL9IV4Nb7sQ"
+              }
+            },
+            "updatedAt":"2019-04-02T12:18:41Z"
+          },
+          "headers":[]
+        }
+
+    http_version: 
+  recorded_at: Tue, 02 Apr 2019 12:18:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/contentful/management/api_key_spec.rb
+++ b/spec/lib/contentful/management/api_key_spec.rb
@@ -58,7 +58,6 @@ module Contentful
 
       describe 'environments' do
         let(:space_id) { 'facgnwwgj5fe' }
-        subject { client.api_keys(space_id) }
 
         it 'can create an api key with environments' do
           vcr('api_key/create_with_environments') {
@@ -88,7 +87,6 @@ module Contentful
       describe 'preview api tokens' do
         let(:space_id) { 'facgnwwgj5fe' }
         let(:api_key_id) { '5mxNhKOZYOp1wzafOR9qPw' }
-        subject { client.api_keys(space_id) }
 
         it 'can fetch preview api keys' do
           vcr('api_key/preview') {
@@ -99,6 +97,24 @@ module Contentful
             preview_api_key = api_key.preview_api_key
             expect(preview_api_key).to be_a Contentful::Management::PreviewApiKey
             expect(preview_api_key.access_token).to eq 'PREVIEW_TOKEN'
+          }
+        end
+      end
+
+      describe 'issues' do
+        let(:space_id) { 'facgnwwgj5fe' }
+        it 'can save an api key - #189' do
+          vcr('api_key/issue_189') {
+            api_key = subject.find('5rjsSfZUvHJnWBDkbcCsem')
+
+            expect(api_key.name).to eq 'test - updated'
+
+            api_key.name = 'test - updated 2'
+            api_key.save
+
+            api_key.reload
+
+            expect(api_key.name).to eq 'test - updated 2'
           }
         end
       end

--- a/spec/lib/contentful/management/environment_spec.rb
+++ b/spec/lib/contentful/management/environment_spec.rb
@@ -122,4 +122,21 @@ describe Contentful::Management::Environment do
       }
     end
   end
+
+  describe 'issues' do
+    it 'can save an environment - #189' do
+      vcr('environment/issue_189') {
+        environment = subject.find('testing')
+
+        expect(environment.name).to eq 'testing'
+
+        environment.name = 'testing 2'
+        environment.save
+
+        environment.reload
+
+        expect(environment.name).to eq 'testing 2'
+      }
+    end
+  end
 end

--- a/spec/lib/contentful/management/locale_spec.rb
+++ b/spec/lib/contentful/management/locale_spec.rb
@@ -161,12 +161,27 @@ module Contentful
       end
 
       describe 'issues' do
-        let!(:space_id) { 'facgnwwgj5fe' }
+        let(:space_id) { 'facgnwwgj5fe' }
         it 'should be able to create a locale with a fallback code' do
           vcr('locale/fallback_code') do
             locale = subject.create(name: 'Foo (BarBaz)', code: 'foo-BB', fallback_code: 'en-US')
 
             expect(subject.find(locale.id).code).to eq 'foo-BB'
+          end
+        end
+
+        it 'can save a locale - #189' do
+          vcr('locale/issue_189') do
+            locale = subject.find('4brXbuf0CeMWo4vlIfWe0q')
+
+            expect(locale.code).to eq 'bar'
+
+            locale.code = 'bar2'
+            locale.save
+
+            locale.reload
+
+            expect(locale.code).to eq 'bar2'
           end
         end
       end

--- a/spec/lib/contentful/management/role_spec.rb
+++ b/spec/lib/contentful/management/role_spec.rb
@@ -5,7 +5,7 @@ require 'contentful/management/client'
 module Contentful
   module Management
     describe Role do
-      let(:token) { '<ACCESS_TOKEN>' }
+      let(:token) { ENV.fetch('CF_TEST_CMA_TOKEN', '<ACCESS_TOKEN>') }
       let(:space_id) { '03vrieuz7eun' }
       let(:role_id) { '0rQMQMd6ZTgeF7hxjz7JDi' }
 
@@ -118,6 +118,25 @@ module Contentful
 
             expect(error).to be_a Contentful::Management::NotFound
           end
+        end
+      end
+
+      describe 'issues' do
+        let(:space_id) { 'facgnwwgj5fe' }
+
+        it 'can save a role - #189' do
+          vcr('roles/issue_189') {
+            role = subject.find('1NzxmNIjPtzpJae5OL1m4u')
+
+            expect(role.name).to eq 'Translator 1'
+
+            role.name = 'Translator - Updated'
+            role.save
+
+            role.reload
+
+            expect(role.name).to eq 'Translator - Updated'
+          }
         end
       end
     end

--- a/spec/lib/contentful/management/space_spec.rb
+++ b/spec/lib/contentful/management/space_spec.rb
@@ -221,6 +221,25 @@ module Contentful
           end
         end
       end
+
+      describe 'issues' do
+        let(:space_id) { 'no8f22w4syte' }
+
+        it 'can save a space - #189' do
+          vcr('space/issue_189') {
+            space = subject.find(space_id)
+
+            expect(space.name).to eq 'foo'
+
+            space.name = 'bar'
+            space.save
+
+            space.reload
+
+            expect(space.name).to eq 'bar'
+          }
+        end
+      end
     end
   end
 end

--- a/spec/lib/contentful/management/webhook_spec.rb
+++ b/spec/lib/contentful/management/webhook_spec.rb
@@ -169,6 +169,25 @@ module Contentful
           end
         end
       end
+
+      describe 'issues' do
+        let(:space_id) { 'facgnwwgj5fe' }
+
+        it 'can properly update attributes - #189' do
+          vcr('webhook/issue_189') do
+            webhook = subject.find('0Kgjs0DQizupIbmSHcyaFM')
+
+            expect(webhook.url).to eq 'https://www.example.com'
+
+            webhook.url = 'https://www.example2.com'
+            webhook.save
+
+            webhook.reload
+
+            expect(webhook.url).to eq 'https://www.example2.com'
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #189 

The issue only reports that `Webhook`s are not properly saving, but the same is true for several other entities that had that method enabled on version `2.5.0`. This PR addresses those resources.