### PR TITLE
Fix Field#properties_to_hash method

### DIFF
--- a/lib/contentful/management/field.rb
+++ b/lib/contentful/management/field.rb
@@ -30,7 +30,8 @@ module Contentful
       # @private
       def properties_to_hash
         properties.each_with_object({}) do |(key, value), results|
-          results[key] = parse_value(key, value)
+          value = parse_value(key, value)
+          results[key] = value if Field.value_exists?(value)
         end
       end
 


### PR DESCRIPTION
On the Field class, when converting the properties to a hash for sending the API request, the method is not avoiding empty values (it does already avoid them when serializing validators).

These cause some requests to fail when trying to creating new content models using an existing (from another model) complex (array or referenced) field as the source.

This small change fixes the issue and allows for complex content model migrations or duplication.

Before:
```ruby
#source_environment = ...
#target_environment = ...
pry(main)> content_model = source_environment.content_types.find('complex_sample_model')
pry(main)> new_content_type = target_environment.content_types.create(id: content_model.id, name: content_model.name, fields: content_model.fields)
=> Contentful::Management::UnprocessableEntity: HTTP status code: 422 Unprocessable Entity
Message: Validation error
Details: 
	* Name: unexpected - Path: '["fields", 1, "items", "id"]' - Value: ''
	* Name: unexpected - Path: '["fields", 1, "items", "items"]' - Value: ''
	* Name: unexpected - Path: '["fields", 1, "items", "name"]' - Value: ''
	* Name: unexpected - Path: '["fields", 1, "items", "omitted"]' - Value: ''
	* Name: unexpected - Path: '["fields", 1, "items", "required"]' - Value: ''
	* Name: unexpected - Path: '["fields", 1, "items", "disabled"]' - Value: ''
	* Name: unexpected - Path: '["fields", 1, "items", "localized"]' - Value: ''
Request ID: 4ba35367324d77bf9610217f1f2eb77c
from /Users/hq063/.rvm/gems/ruby-2.5.1@juulio/gems/contentful-management-2.6.0/lib/contentful/management/client.rb:390:in `execute_request'
```

With this fix:
```ruby
#source_environment = ...
#target_environment = ...
pry(main)> content_model = source_environment.content_types.find('complex_sample_model')
pry(main)> new_content_type = target_environment.content_types.create(id: content_model.id, name: content_model.name, fields: content_model.fields)
#<Contentful::Management::ContentType: @properties=....>
```
