### PR TITLE
Add missing rich text validation options

### DIFF
--- a/lib/contentful/management/validation.rb
+++ b/lib/contentful/management/validation.rb
@@ -17,6 +17,8 @@ module Contentful
       property :linkContentType, :array
       property :linkMimetypeGroup, :string
       property :assetImageDimensions, :hash
+      property :enabledNodeTypes, :array
+      property :enabledMarks, :array
 
       # @private
       def properties_to_hash


### PR DESCRIPTION
According to https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types/content-type `enabledNodeTypes` and `enabledMarks` are available in the API but they are missing in `Contentful::Management::Validation` 
This PR adds them