### PR TITLE
Do not pass default_locale to `Contentful::Management::Resource.initialize`

### DIFF
--- a/lib/contentful/management/environment.rb
+++ b/lib/contentful/management/environment.rb
@@ -139,8 +139,9 @@ module Contentful
       # @return [String]
       def find_locale
         locale = locales.all.detect(&:default)
-        return locale.code unless locale.nil?
-        @default_locale
+        return locale.code if locale
+
+        default_locale
       end
 
       # @private

--- a/lib/contentful/management/resource.rb
+++ b/lib/contentful/management/resource.rb
@@ -27,18 +27,16 @@ module Contentful
       }.freeze
       # rubocop:enable Style/DoubleNegation
 
-      attr_reader :properties, :request, :default_locale, :raw_object
+      attr_reader :properties, :request, :raw_object
       attr_accessor :client
 
       # @private
       def initialize(object = nil,
                      request = nil,
                      client = nil,
-                     nested_locale_fields = false,
-                     default_locale = Contentful::Management::Client::DEFAULT_CONFIGURATION[:default_locale])
+                     nested_locale_fields = false)
         self.class.update_coercions!
         @nested_locale_fields = nested_locale_fields
-        @default_locale = default_locale
 
         @properties = extract_from_object object, :property, self.class.property_coercions.keys
         @request = request
@@ -132,6 +130,11 @@ module Contentful
       # Returns the Environment ID
       def environment_id
         nil
+      end
+
+      # Get default_locale from client
+      def default_locale
+        client.default_locale
       end
 
       protected

--- a/lib/contentful/management/resource_builder.rb
+++ b/lib/contentful/management/resource_builder.rb
@@ -73,7 +73,6 @@ module Contentful
         @included_resources = {}
         @known_resources = Hash.new { |hash, key| hash[key] = {} }
         @nested_locales = true
-        @default_locale = (client.configuration || Contentful::Management::Client::DEFAULT_CONFIGURATION)[:default_locale]
         @resource_mapping = default_resource_mapping.merge(resource_mapping)
         @entry_mapping = default_entry_mapping.merge(entry_mapping)
       end
@@ -113,7 +112,7 @@ module Contentful
       def create_resource(object)
         res_class = detect_resource_class(object)
         @nested_locales ||= res_class.nested_locale_fields?
-        res = res_class.new(object, response.request, client, @nested_locales, @default_locale)
+        res = res_class.new(object, response.request, client, @nested_locales)
 
         add_to_known_resources res
         replace_children res, object


### PR DESCRIPTION
This PR addresses a problem similar to https://github.com/contentful/contentful-management.rb/issues/73
So if `default_locale` is different from `Contentful::Management::Client::DEFAULT_CONFIGURATION[:default_locale]`(`en-US`) `entries.new` with `entries.save` doesn't work correctly.
Basically, it ignores non-localised fields set with a setter

Let's assume `en-GB` is a default locale and there is a content type with two fields:
- slug - regular text field
- name - localised text field

The code below ignores `slug` field and set only `name` field on Contentful
```ruby
new_entry = content_type.entries.new
new_entry.slug = 'my-slug'
new_entry.name_with_locales = { 'en-GB' => 'GB title', 'en-IE' => 'IE title' }
new_entry.save
```
 
This is because we don't pass `default_locale` when we instantiate `DynamicEntry` here https://github.com/contentful/contentful-management.rb/blob/master/lib/contentful/management/content_type_entry_methods_factory.rb#L47 so as result `default_locale`(that is used [here](https://github.com/contentful/contentful-management.rb/blob/master/lib/contentful/management/resource/field_aware.rb#L67) as part of a `name_with_locales=` setter) is taken from `Contentful::Management::Client::DEFAULT_CONFIGURATION[:default_locale]`