### PR TITLE
Fix EnvironmentAware#environment_id when building entries or assets

### DIFF
--- a/lib/contentful/management/resource/environment_aware.rb
+++ b/lib/contentful/management/resource/environment_aware.rb
@@ -6,14 +6,17 @@ module Contentful
         # Gets the environment ID for the resource.
         def environment_id
           env = sys.fetch(:environment, {})
-          case env
-          when ::Hash
-            env.fetch(:id, 'master')
-          when ::Contentful::Management::Link
-            env.id
-          else
-            'master'
-          end
+          env_from_sys =
+            case env
+            when ::Hash
+              env.fetch(:id, nil)
+            when ::Contentful::Management::Link, ::Contentful::Management::Environment
+              env.id
+            end
+
+          return env_from_sys if env_from_sys
+
+          respond_to?(:content_type) && content_type && content_type.environment_id || 'master'
         end
       end
     end


### PR DESCRIPTION
Currently both `content_type.entries.new` and `environment.assets.new`(basically `ContentTypeEntryMethodsFactory#new` and `EnvironmentEntryMethodsFactory#new`) don't work corrently when enviorment is not `master`. An object that is returned is always targeted to `master`

### `content_type.entries.new` case

In this case, `enviorment_id` doesn't calculate properly, because `sys` doesn't really have any information about the current environment. But there is `content_type` reader that has `#enviorment_id`.

### `environment.assets.new` case

In this case, `sys[:enviorment]` is present, but it is not `Contentful::Management::Link`, it is  `Contentful::Management::Environment`. 

This PR extends `EnvironmentAware#environment_id` and adds support for both cases. It might even fix other similar cases

It would be great to cover that with integrations specs. Unfortunately, I don't have access to the testing Contentful account, so I can just draft the specs but they need to be finalised by someone with the access