### PR TITLE
Relax json gem version between 1.8 and 2.x

### DIFF
--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'http', '> 1.0', '< 3.0'
   spec.add_dependency 'multi_json', '~> 1'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'json', '>= 1.8', '< 3.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '< 11.0'


### PR DESCRIPTION
Here's the changelog for json 2.x: https://github.com/flori/json/blob/master/CHANGES.md

2.x adds better compatibility with ruby 2.4, 2.6 and RFC 7159 compliance and so it seems like it would be a good idea to support it.

Not to mention, I have a conflicting dependency that requires json > 2.x.

Related to: https://github.com/contentful/contentful-management.rb/issues/151