### PR TITLE
Support query parameters on space retrieving

### DIFF
--- a/lib/contentful/management/client_space_methods_factory.rb
+++ b/lib/contentful/management/client_space_methods_factory.rb
@@ -15,8 +15,8 @@ module Contentful
       # Gets a collection of spaces.
       #
       # @return [Contentful::Management::Array<Contentful::Management::Space>]
-      def all
-        @resource_requester.all
+      def all(query = {})
+        @resource_requester.all({}, query)
       end
 
       # Gets a specific space.

--- a/lib/contentful/management/space.rb
+++ b/lib/contentful/management/space.rb
@@ -35,8 +35,8 @@ module Contentful
       # @param [Contentful::Management::Client] client
       #
       # @return [Contentful::Management::Array<Contentful::Management::Space>]
-      def self.all(client)
-        ClientSpaceMethodsFactory.new(client).all
+      def self.all(client, query = {})
+        ClientSpaceMethodsFactory.new(client).all(query)
       end
 
       # Gets a specific space.


### PR DESCRIPTION
When doing `client.spaces.all` or `Contentful::Management::Space.all(client)` the current implementation doesn't accepts arguments for passing into the query string. That behaviour disallows developers to change pagination options like `limit` or `skip`.

This PR allows both methods to receive a hash with parameters that will be included in the query string.

Before:
```ruby
[1] pry(main)> client = Contentful::Management::Client.new(ENV['CONTENTFUL_MANAGEMENT_API_KEY'])
=> #<Contentful::Management::Client:0x00007fb4671c89a0 ...>
[2] pry(main)> client.spaces.all(limit: 10)
ArgumentError: wrong number of arguments (given 1, expected 0)
from ...contentful-management-2.8.2/lib/contentful/management/client_space_methods_factory.rb:18:in `all`
[3] pry(main)> Contentful::Management::Space.all(client, limit: 10)
ArgumentError: wrong number of arguments (given 2, expected 1)
from ...contentful-management-2.8.2/lib/contentful/management/space.rb:38:in `all`
```

With this PR:
```ruby
[1] pry(main)> client = Contentful::Management::Client.new(ENV['CONTENTFUL_MANAGEMENT_API_KEY'])
=> #<Contentful::Management::Client:0x00007f8e1defe090 ...>
[2] pry(main)> client.spaces.all(limit: 10)
=> #<Contentful::Management::Array:  ...>
[3] pry(main)> Contentful::Management::Space.all(client, limit: 10)
=> #<Contentful::Management::Array: ...>

```