### PR TITLE
Bump json gem to latest (2.2.0) from '~> 1.8'

### DIFF
--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'http', '> 1.0', '< 3.0'
   spec.add_dependency 'multi_json', '~> 1'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'json', '>= 1.8', '< 3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '< 11.0'


### PR DESCRIPTION
The only breaking change is that the 2.0 version of json dropped support
for old rubies:

> Drops support for old rubies whose life has ended, that is
> rubies < 2.0. Also see https://www.ruby-lang.org/en/news/2014/07/01/eol-for-1-8-7-and-1-9-2/
From: https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200