### PR TITLE
Ignore empty hashes in Field#validations_to_hash

### DIFF
--- a/lib/contentful/management/field.rb
+++ b/lib/contentful/management/field.rb
@@ -87,7 +87,9 @@ module Contentful
 
       def validations_to_hash(validations)
         validations.each_with_object([]) do |validation, results|
-          results << validation.properties_to_hash
+          validation_hash = validation.properties_to_hash
+
+          results << validation.properties_to_hash if Field.value_exists?(validation_hash)
         end
       end
     end


### PR DESCRIPTION
There is a chance that `Contentful::Management::Validation#properties_to_hash` generates an empty hash. 
For example, in my case the `nodes` fields was `{}` so the `#properties_to_hash` returned an empty hash.

This PR makes sure such values are ignored during submission.
Because otherwise the API throws the `Name: size - Path: '["fields", <index>, "validations", <index>]' - Value: ''` error because the validation hash is empty