### PR TITLE
Move Travis CI to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Contentful::Management
-[![Gem Version](https://badge.fury.io/rb/contentful-management.svg)](http://badge.fury.io/rb/contentful-management) [![Build Status](https://travis-ci.org/contentful/contentful-management.rb.svg)](https://travis-ci.org/contentful/contentful-management.rb)
+[![Gem Version](https://badge.fury.io/rb/contentful-management.svg)](http://badge.fury.io/rb/contentful-management) [![Build Status](https://app.travis-ci.com/contentful/contentful-management.rb.svg?branch=master)](https://app.travis-ci.com/contentful/contentful-management.rb)
 
 Ruby client for the Contentful Content Management API.
 


### PR DESCRIPTION
Transfer [one on travis-ci.org](https://travis-ci.org/github/contentful/contentful-management.rb) to [app.travis-ci.com](https://app.travis-ci.com/github/contentful/contentful-management.rb) like [other repos on Contentful](https://app.travis-ci.com/github/contentful) since .org was shut down on June 15th, 2021.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>