### PR TITLE
Clear headers after request is fully complete

### DIFF
--- a/lib/contentful/management/client.rb
+++ b/lib/contentful/management/client.rb
@@ -393,7 +393,6 @@ module Contentful
           logger.info(request: { url: url, query: request.query, header: request_headers(request) }) if logger
           raw_response = yield(url)
           logger.debug(response: raw_response) if logger
-          clear_headers
           result = Response.new(raw_response, request)
           fail result.object if result.object.is_a?(Error) && configuration[:raise_errors]
         rescue Contentful::Management::RateLimitExceeded => rate_limit_error
@@ -406,6 +405,8 @@ module Contentful
           end
 
           raise
+        ensure
+          clear_headers
         end
 
         result

--- a/spec/fixtures/vcr_cassettes/entry/too_many_requests_retry.yml
+++ b/spec/fixtures/vcr_cassettes/entry/too_many_requests_retry.yml
@@ -743,7 +743,7 @@ http_interactions:
       Content-Type:
       - application/vnd.contentful.management.v1+json
       X-Contentful-Version:
-      - '30'
+      - '1'
       Content-Length:
       - '0'
       Host:

--- a/spec/lib/contentful/management/entry_spec.rb
+++ b/spec/lib/contentful/management/entry_spec.rb
@@ -456,7 +456,12 @@ describe Contentful::Management::Entry do
     end
 
     it 'too many requests auto-retry' do
-      vcr('entry/too_many_requests_retry') do
+      # Testing that the header versions are not cleared between retries
+      header_matcher = lambda do |request_1, request_2|
+        request_1.headers["X-Contentful-Version"] == request_2.headers["X-Contentful-Version"]
+      end
+
+      VCR.use_cassette('entry/too_many_requests_retry', match_requests_on: [:method, :uri, header_matcher]) do
         logger = RetryLoggerMock.new(STDOUT)
         space = Contentful::Management::Client.new(token, raise_errors: true, logger: logger).spaces.find('286arvy86ry9')
         invalid_entry = client.entries(space.id, 'master').find('1YNepnMpXGiMWikaKC4GG0')


### PR DESCRIPTION
Ensures that headers are only cleared after the request is _fully_ complete.

Ref: #244 