### PR TITLE
configure VCR to redact CMA tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master
 * Updated readme for Entry References
 * Added examples of fetching entries by field values in readme
+* Configured VCR to redact sensitive data
 
 ## 3.5.0
 * Added support for Entry References API

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -8,9 +8,10 @@ VCR.configure do |c|
 
   # Redact Contentful Management API tokens from VCR recordings
   c.filter_sensitive_data('<ACCESS_TOKEN>') do |interaction|
-    auths = interaction.request.headers['Authorization'].first
-    if (match = auths.match(/^Bearer\s+([^,\s]+)/))
-      match.captures.first
+    if (auths = interaction.request.headers['Authorization']&.first)
+      if (match = auths.match(/^Bearer\s+([^,\s]+)/))
+        match.captures.first
+      end
     end
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -5,6 +5,14 @@ VCR.configure do |c|
   c.ignore_localhost = true
   c.hook_into :webmock
   c.default_cassette_options = {record: :once}
+
+  # Redact Contentful Management API tokens from VCR recordings
+  c.filter_sensitive_data('<ACCESS_TOKEN>') do |interaction|
+    auths = interaction.request.headers['Authorization'].first
+    if (match = auths.match(/^Bearer\s+([^,\s]+)/))
+      match.captures.first
+    end
+  end
 end
 
 def vcr(name, &block)


### PR DESCRIPTION
@rubydog this will prevent contributors from accidentally committing their CMA tokens in VCR cassettes

reference: https://relishapp.com/vcr/vcr/v/3-0-1/docs/configuration/filter-sensitive-data 