### PR TITLE
address deprecation of URI.escape in uri v0.10.1 (see: https://github.com/ruby/uri/pull/9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Master
+* Replaces deprecated `URI.escape` with `URI.encode_www_form_component` in Contentful::Management::Request#id
 * Configured VCR to redact sensitive data
 
 ## 3.6.0

--- a/lib/contentful/management/request.rb
+++ b/lib/contentful/management/request.rb
@@ -24,7 +24,7 @@ module Contentful
 
         if id
           @type = :single
-          @id = URI.escape(id)
+          @id = URI.encode_www_form_component(id)
         else
           @type = :multi
           @id = nil


### PR DESCRIPTION
addresses issue 251 https://github.com/contentful/contentful-management.rb/issues/251 

cc: @rubydog 