### PR TITLE
Fix an issue when updating editor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unlreleased
 * Added defaultValue field property
 * Added delete field property
+* Fixed an issue when updating editor interface with sidebar
 
 ## 3.9.0
 * Update ruby versions in CI/CD

--- a/lib/contentful/management/editor_interface.rb
+++ b/lib/contentful/management/editor_interface.rb
@@ -74,8 +74,8 @@ module Contentful
           },
           {
             'controls' => attributes[:controls] || controls,
-            'sidebar' => attributes[:sidebar] || sidebar
-          },
+            'sidebar' => attributes.fetch(:sidebar, sidebar)
+          }.compact,
           version: sys[:version]
         )
       end


### PR DESCRIPTION
This PR fixes the issue described in #240, which was closed without a proper fix.


The way the Contentful Management API works for the sidebar on the editor interface is not compatible with the current behaviour on the gem:

- When sidebar is not customized, API doesn't include the attribute on the response
- Gem currently provides a default nil value for the sidebar when is not included
- When updating the editor interface, gem posts the nil sidebar to the API
- The API does not accept a nil value for this attribute, it expects it to not be present if not customized, or have a value if there is some customization.

That causes `editor_interface.update(controls: some_controls)` to fail if sidebar is not customized:
```
Message: Validation error
Details:
	* Name: type - Path: '["sidebar"]' - Value: ''
```

And if you try to explicitly set a valid value, there is no way to get the current sidebar value, as API does not provide it when it's default. Also, sending `sidebar: []` works for bypassing the error, but the behaviour on the API is not to keep the default sidebar but to customize it to an empty sidebar (not even publish button).

To avoid this issue, the way that API expects the request is for the sidebar not to be present on an update request when it's not supposed to be customized. With this change, now you can:

- `editor_interface.update(controls: some_controls)`: to keep the current sidebar exactly as it is, either customized or not customized.
- `editor_interface.update(controls: some_controls, sidebar: some_sidebar)`: updates to a customized sidebar
- `editor_interface.update(controls: some_controls, sidebar: nil)`: resets sidebar to default