### PR TITLE
Add optional chaining to fix NoMethodError

### DIFF
--- a/lib/contentful/management/resource.rb
+++ b/lib/contentful/management/resource.rb
@@ -93,7 +93,7 @@ module Contentful
 
       # @private
       def inspect(info = nil)
-        properties_info = properties.empty? ? '' : " @properties=#{properties.inspect}"
+        properties_info = properties&.empty? ? '' : " @properties=#{properties.inspect}"
         "#<#{self.class}:#{properties_info}#{info}>"
       end
 


### PR DESCRIPTION
Hi,

For some reason during my use of the gem I ran into this issue when trying to print out some entries while debugging. I can't seem to find an easy way to add spec coverage here but this solves a `NoMethodError` when properties are `nil`. Feel free to push specs for coverage or point me out how to do so if needed.

Thanks!