### PR TITLE
Fix call to #editor_interfaces.all on an environment

### DIFF
--- a/lib/contentful/management/editor_interface.rb
+++ b/lib/contentful/management/editor_interface.rb
@@ -52,9 +52,15 @@ module Contentful
       def self.build_endpoint(endpoint_options)
         space_id = endpoint_options.fetch(:space_id)
         environment_id = endpoint_options.fetch(:environment_id)
-        content_type_id = endpoint_options.fetch(:content_type_id)
 
-        "spaces/#{space_id}/environments/#{environment_id}/content_types/#{content_type_id}/editor_interface"
+        base_path = "spaces/#{space_id}/environments/#{environment_id}"
+
+        if endpoint_options.key?(:content_type_id)
+          content_type_id = endpoint_options.fetch(:content_type_id)
+          "#{base_path}/content_types/#{content_type_id}/editor_interface"
+        else
+          "#{base_path}/editor_interfaces"
+        end
       end
 
       # Updates an Editor Interface


### PR DESCRIPTION
Fix `KeyError: key not found: :content_type_id` error when calling `environment.editor_interfaces.all`.

Environments have [an endpoint](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/editor-interface/editor-interface-collection/get-all-editor-interfaces-of-a-space/console) to retrieve all the editor interfaces at once, but currently the management SDK method that's supposed to use that endpoint is not working as expected.