### PR TITLE
fix:[RUBY-101]update specs to match new json parse error messaging

### DIFF
--- a/spec/lib/contentful/management/error_class_spec.rb
+++ b/spec/lib/contentful/management/error_class_spec.rb
@@ -314,7 +314,7 @@ describe Contentful::Management::Error do
       it 'returns the json parser\'s message' do
         uj = Contentful::Management::Response.new raw_fixture('unparsable'), MockRequest.new
         expect(Contentful::Management::UnparsableJson.new(uj).message).to \
-            include 'unexpected token'
+            include "expected ',' or '}' after object value"
       end
     end
   end


### PR DESCRIPTION
A spec was failing because it relied on a specific error message being present when there were JSON parsing errors. The latest Ruby JSON parser has different, more specific, error messaging and so the spec was updated to check accordingly.