### PR TITLE
Test against Ruby 4.0 and fix compatibility issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v5
 

--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'
-  spec.add_development_dependency 'public_suffix', '< 1.5'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'guard'
@@ -33,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-yard'
   spec.add_development_dependency 'rubocop', '~> 1.56.2'
   spec.add_development_dependency 'listen', '~> 3.0'
-  spec.add_development_dependency 'vcr', '~> 6.2.0'
+  spec.add_development_dependency 'vcr', '~> 6.4'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'tins', '~> 1.6.0'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
`vcr` need to be updated to handle the Ruby 4.0 CGI module extraction.

`public_suffix <= 1.5` is extremely ancient and prevent using newer versions of webmock.