### PR TITLE
Allow and fix compatibility with http 6.x 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v5
 

--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '~> 5.0'
+  spec.add_dependency 'http', '>= 5.0'
   spec.add_dependency 'multi_json', '~> 1.15'
   spec.add_dependency 'json', '>= 1.8', '< 3.0'
 

--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'
-  spec.add_development_dependency 'public_suffix', '< 1.5'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'guard'
@@ -33,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-yard'
   spec.add_development_dependency 'rubocop', '~> 1.56.2'
   spec.add_development_dependency 'listen', '~> 3.0'
-  spec.add_development_dependency 'vcr', '~> 6.2.0'
+  spec.add_development_dependency 'vcr', '~> 6.4'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'tins', '~> 1.6.0'
   spec.add_development_dependency 'simplecov'

--- a/lib/contentful/management/client.rb
+++ b/lib/contentful/management/client.rb
@@ -418,7 +418,11 @@ module Contentful
           result = Response.new(raw_response, request)
           fail result.object if result.object.is_a?(Error) && configuration[:raise_errors]
         rescue Contentful::Management::RateLimitExceeded => e
-          reset_time = e.response.raw[RATE_LIMIT_RESET_HEADER_KEY].to_i
+          reset_time = if HTTP::VERSION < "6"
+            e.response.raw[RATE_LIMIT_RESET_HEADER_KEY].to_i
+          else
+            e.response.raw.headers[RATE_LIMIT_RESET_HEADER_KEY].to_i
+          end
           if should_retry(retries_left, reset_time, configuration[:max_rate_limit_wait])
             retries_left -= 1
             logger.info(retry_message(retries_left, reset_time)) if logger
@@ -516,7 +520,7 @@ module Contentful
           proxy[:port],
           proxy[:username],
           proxy[:password]
-        ).public_send(type, url, params)
+        ).public_send(type, url, **params)
       end
 
       # HTTP Helper
@@ -532,7 +536,7 @@ module Contentful
       def http_send(type, url, params, headers, proxy)
         return proxy_send(type, url, params, headers, proxy) unless proxy[:host].nil?
 
-        HTTP[headers].public_send(type, url, params)
+        HTTP[headers].public_send(type, url, **params)
       end
 
       # @private

--- a/lib/contentful/management/error.rb
+++ b/lib/contentful/management/error.rb
@@ -20,6 +20,8 @@ module Contentful
       # Shortcut for creating specialized error classes
       # USAGE rescue Contentful::Management::Error[404]
       def self.[](error_status_code)
+        error_status_code = error_status_code&.code unless error_status_code.is_a?(Integer)
+
         errors = {
           400 => BadRequest,
           401 => Unauthorized,
@@ -193,8 +195,14 @@ module Contentful
       end
 
       # Time until next available request, in seconds.
-      def reset_time
-        @reset_time ||= @response.raw[RATE_LIMIT_RESET_HEADER_KEY]
+      if HTTP::VERSION < "6"
+        def reset_time
+          @reset_time ||= @response.raw[RATE_LIMIT_RESET_HEADER_KEY]
+        end
+      else
+        def reset_time
+          @reset_time ||= @response.raw.headers[RATE_LIMIT_RESET_HEADER_KEY]
+        end
       end
 
       protected


### PR DESCRIPTION
Based of: https://github.com/contentful/contentful-management.rb/pull/282

`http 5.x` is no longer maintained and doesn't build on Ruby 4.1.0dev
(to be released in december).

So for `contentful-management` to work on the upcoming Ruby 4.1,
it must support `http 6.x`.

Supporting both versions isn't too much trouble.

I specifically chose to support both versions because `http` isn't a rare dependency, so it's best if `contentful-management` can be updated even if another gem is still pinning `http 5.x`.