### PR TITLE
Remove dependency on `json`

### DIFF
--- a/contentful-management.gemspec
+++ b/contentful-management.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'http', '~> 5.0'
   spec.add_dependency 'multi_json', '~> 1.15'
-  spec.add_dependency 'json', '>= 1.8', '< 3.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '>= 12.3.3'


### PR DESCRIPTION
The gem uses `multi_json` hence there is no point having a dependency on the `json` gem.