### PR TITLE
feat(usage): deprecate legacy periodic-usage endpoints [MOI-7251]

### DIFF
--- a/lib/contentful/management/client.rb
+++ b/lib/contentful/management/client.rb
@@ -141,16 +141,28 @@ module Contentful
       # Allows listing all usage periods for organization grouped by organization.
       # @see _ README for details.
       #
+      # @deprecated The `GET /organizations/:organization_id/organization_periodic_usages`
+      #   endpoint is deprecated in favor of the new Usage API. It will be removed on
+      #   2027-02-28, after which requests will return 410 Gone.
       # @return [Contentful::Management::ClientOrganizationPeriodicUsageMethodsFactory]
       def organization_periodic_usages(organization_id)
+        warn '[DEPRECATION] `Client#organization_periodic_usages` calls the legacy ' \
+             'organization_periodic_usages endpoint, which is deprecated and will be ' \
+             'removed on 2027-02-28. Migrate to the new Usage API.'
         ClientOrganizationPeriodicUsageMethodsFactory.new(self, organization_id)
       end
 
       # Allows listing all usage periods for organization grouped by space.
       # @see _ README for details.
       #
+      # @deprecated The `GET /organizations/:organization_id/space_periodic_usages`
+      #   endpoint is deprecated in favor of the new Usage API. It will be removed on
+      #   2027-02-28, after which requests will return 410 Gone.
       # @return [Contentful::Management::ClientSpacePeriodicUsageMethodsFactory]
       def space_periodic_usages(organization_id)
+        warn '[DEPRECATION] `Client#space_periodic_usages` calls the legacy ' \
+             'space_periodic_usages endpoint, which is deprecated and will be ' \
+             'removed on 2027-02-28. Migrate to the new Usage API.'
         ClientSpacePeriodicUsageMethodsFactory.new(self, organization_id)
       end
 

--- a/lib/contentful/management/client_organization_periodic_usage_methods_factory.rb
+++ b/lib/contentful/management/client_organization_periodic_usage_methods_factory.rb
@@ -6,6 +6,8 @@ module Contentful
   module Management
     # Wrapper for Organization Periodic Usages for usage from within Client
     # @private
+    # @deprecated Wraps the legacy organization_periodic_usages endpoint, which is
+    #   deprecated in favor of the new Usage API and will be removed on 2027-02-28.
     class ClientOrganizationPeriodicUsageMethodsFactory
       include Contentful::Management::ClientAssociationMethodsFactory
 
@@ -14,6 +16,8 @@ module Contentful
         @organization_id = organization_id
       end
 
+      # @deprecated Calls the legacy organization_periodic_usages endpoint, which is
+      #   deprecated in favor of the new Usage API and will be removed on 2027-02-28.
       def all(params = {})
         @resource_requester.all(
           {

--- a/lib/contentful/management/client_space_periodic_usage_methods_factory.rb
+++ b/lib/contentful/management/client_space_periodic_usage_methods_factory.rb
@@ -6,6 +6,8 @@ module Contentful
   module Management
     # Wrapper for Space Periodic Usages for usage from within Client
     # @private
+    # @deprecated Wraps the legacy space_periodic_usages endpoint, which is
+    #   deprecated in favor of the new Usage API and will be removed on 2027-02-28.
     class ClientSpacePeriodicUsageMethodsFactory
       include Contentful::Management::ClientAssociationMethodsFactory
 
@@ -14,6 +16,8 @@ module Contentful
         @organization_id = organization_id
       end
 
+      # @deprecated Calls the legacy space_periodic_usages endpoint, which is
+      #   deprecated in favor of the new Usage API and will be removed on 2027-02-28.
       def all(params = {})
         @resource_requester.all(
           {

--- a/lib/contentful/management/organization_periodic_usage.rb
+++ b/lib/contentful/management/organization_periodic_usage.rb
@@ -6,6 +6,8 @@ module Contentful
   module Management
     # Resource class for OrganizationPeriodicUsage.
     # @see _ https://www.contentful.com/developers/docs/references/content-management-api/#/reference/usage/organization-usage/get-organization-usage/console/curl
+    # @deprecated Backed by the legacy organization_periodic_usages endpoint, which is
+    #   deprecated in favor of the new Usage API and will be removed on 2027-02-28.
     class OrganizationPeriodicUsage
       include Contentful::Management::Resource
       include Contentful::Management::Resource::Refresher
@@ -30,8 +32,13 @@ module Contentful
       # @param [String] organization_id
       # @param [Hash] params
       #
+      # @deprecated The legacy organization_periodic_usages endpoint is deprecated in
+      #   favor of the new Usage API and will be removed on 2027-02-28.
       # @return [Contentful::Management::Array<Contentful::Management::OrganizationPeriodicUsage>]
       def self.all(client, organization_id, params = {})
+        warn '[DEPRECATION] `OrganizationPeriodicUsage.all` calls the legacy ' \
+             'organization_periodic_usages endpoint, which is deprecated and will be ' \
+             'removed on 2027-02-28. Migrate to the new Usage API.'
         ClientOrganizationPeriodicUsageMethodsFactory.new(client, organization_id).all(params)
       end
 

--- a/lib/contentful/management/space_periodic_usage.rb
+++ b/lib/contentful/management/space_periodic_usage.rb
@@ -6,6 +6,8 @@ module Contentful
   module Management
     # Resource class for SpacePeriodicUsage.
     # @see _ https://www.contentful.com/developers/docs/references/content-management-api/#/reference/usage/space-usage/get-space-usage/console/curl
+    # @deprecated Backed by the legacy space_periodic_usages endpoint, which is
+    #   deprecated in favor of the new Usage API and will be removed on 2027-02-28.
     class SpacePeriodicUsage
       include Contentful::Management::Resource
       include Contentful::Management::Resource::Refresher
@@ -30,8 +32,13 @@ module Contentful
       # @param [String] organization_id
       # @param [Hash] params
       #
+      # @deprecated The legacy space_periodic_usages endpoint is deprecated in favor
+      #   of the new Usage API and will be removed on 2027-02-28.
       # @return [Contentful::Management::Array<Contentful::Management::SpacePeriodicUsage>]
       def self.all(client, organization_id, params = {})
+        warn '[DEPRECATION] `SpacePeriodicUsage.all` calls the legacy ' \
+             'space_periodic_usages endpoint, which is deprecated and will be ' \
+             'removed on 2027-02-28. Migrate to the new Usage API.'
         ClientSpacePeriodicUsageMethodsFactory.new(client, organization_id).all(params)
       end
 


### PR DESCRIPTION
Ticket: https://contentful.atlassian.net/browse/MOI-7251 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds deprecation warnings to the legacy periodic-usage endpoints (organization_periodic_usages and space_periodic_usages) across the Contentful Management Ruby SDK. The changes affect 5 files by adding YARD @deprecated annotations and runtime warning messages that inform developers to migrate to the new Usage API before the 2027-02-28 removal date.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds runtime deprecation warnings in client.rb to organization_periodic_usages and space_periodic_usages methods, alerting users the legacy endpoints will be removed on 2027-02-28</li>

<li>Marks ClientOrganizationPeriodicUsageMethodsFactory and its all method as deprecated with YARD documentation</li>

<li>Marks ClientSpacePeriodicUsageMethodsFactory and its all method as deprecated with YARD documentation</li>

<li>Adds deprecation notices to OrganizationPeriodicUsage and SpacePeriodicUsage resource classes and their static all methods, directing users to migrate to the new Usage API</li>

</ul>
</details>

</div>